### PR TITLE
Stop pulling total_daily_energy from ESPHome dev

### DIFF
--- a/components/pool_controller/README.md
+++ b/components/pool_controller/README.md
@@ -18,7 +18,7 @@ external_components:
     components: [ pool_controller ]
 ```
 
-Add and configure the Pool COntroller Component
+Add and configure the Pool Controller Component
 ```yaml
 pool_controller:
   pump:

--- a/devices/basement_bathroom_light_fan.yaml
+++ b/devices/basement_bathroom_light_fan.yaml
@@ -18,8 +18,6 @@ external_components:
     components: [ binary_light_with_power ]
   - source: github://cbpowell/ESPSense
     components: [ espsense ]
-  - source: github://esphome/esphome@dev
-    components: [ total_daily_energy ]
 
 binary_sensor:
   - platform: gpio

--- a/devices/basement_bathroom_shower_light_heater.yaml
+++ b/devices/basement_bathroom_shower_light_heater.yaml
@@ -18,8 +18,6 @@ external_components:
     components: [ binary_light_with_power, gpio_switch_with_power ]
   - source: github://cbpowell/ESPSense
     components: [ espsense ]
-  - source: github://esphome/esphome@dev
-    components: [ total_daily_energy ]
 
 binary_sensor:
   - platform: gpio

--- a/devices/patio_lights.yaml
+++ b/devices/patio_lights.yaml
@@ -18,8 +18,6 @@ external_components:
     components: [ binary_light_with_power ]
   - source: github://cbpowell/ESPSense
     components: [ espsense ]
-  - source: github://esphome/esphome@dev
-    components: [ total_daily_energy ]
 
 espsense:
   plugs:

--- a/devices/pool_and_patio_lights.yaml
+++ b/devices/pool_and_patio_lights.yaml
@@ -18,8 +18,6 @@ external_components:
     components: [ treo_led_pool_light, binary_light_with_power ]
   - source: github://cbpowell/ESPSense
     components: [ espsense ]
-  - source: github://esphome/esphome@dev
-    components: [ total_daily_energy ]
 
 binary_sensor:
   - platform: gpio

--- a/devices/pool_pumps.yaml
+++ b/devices/pool_pumps.yaml
@@ -16,8 +16,6 @@ external_components:
       type: local
       path: ../components 
     components: [ pool_controller ]
-  - source: github://esphome/esphome@dev
-    components: [ total_daily_energy ]
   - source: github://cbpowell/ESPSense
     components: [ espsense ]
 

--- a/packages/feit_dimmer.yaml
+++ b/packages/feit_dimmer.yaml
@@ -9,8 +9,6 @@ external_components:
     components: [ tuya_light_plus ]
   - source: github://cbpowell/ESPSense
     components: [ espsense ]
-  - source: github://esphome/esphome@dev
-    components: [ total_daily_energy ]
 
 espsense:
   plugs:

--- a/packages/feit_dimmer_as_fan.yaml
+++ b/packages/feit_dimmer_as_fan.yaml
@@ -9,8 +9,6 @@ external_components:
     components: [ tuya_dimmer_as_fan ]
   - source: github://cbpowell/ESPSense
     components: [ espsense ]
-  - source: github://esphome/esphome@dev
-    components: [ total_daily_energy ]
 
 packages:
   base:   !include device_base.yaml


### PR DESCRIPTION
Now that the updated version of total_daily_energy is in the current release we can stop pulling it in as an external component from the ESPHome dev branch.