### PR TITLE
Updates and improvements to the Bed Sensor component

### DIFF
--- a/components/bed_sensor/README.md
+++ b/components/bed_sensor/README.md
@@ -61,5 +61,5 @@ bed_sensor:
 * **someone_sensor** (Required): Binary sensor that is `true` when someone is in the bed but in the middle not one side or the other.
   * **status_name** (Required, string): The name used in the status text sensor for this state.
   * Other standard binary sensor options.
-* **count_sensor** (Required): Numeric sensor reporting the total number of occupants detected (0–3).
+* **count_sensor** (Required): Numeric sensor reporting the total number of occupants detected (0–2).
 * **status_sensor** (Required): Text sensor reporting a human-readable occupancy status (e.g. "Empty", "Alice", "Alice and Bob").

--- a/components/bed_sensor/__init__.py
+++ b/components/bed_sensor/__init__.py
@@ -7,6 +7,7 @@ from esphome.components import text_sensor
 from esphome.const import CONF_ID, CONF_OUTPUT, DEVICE_CLASS_OCCUPANCY, ENTITY_CATEGORY_DIAGNOSTIC
 
 CODEOWNERS = ["@nuttytree"]
+AUTO_LOAD = ["binary_sensor", "sensor", "text_sensor"]
 
 adc_ns = cg.esphome_ns.namespace("adc")
 ADCSensor = adc_ns.class_("ADCSensor")
@@ -75,38 +76,23 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 
-    adc_sensor = await cg.get_variable(config[CONF_ADC_SENSOR])
-    cg.add(var.set_adc_sensor(adc_sensor))
-    
+    cg.add(var.set_adc_sensor(await cg.get_variable(config[CONF_ADC_SENSOR])))
+
     side_one_config = config[CONF_SIDE_ONE]
     cg.add(var.set_side_one_name(side_one_config[CONF_STATUS_NAME]))
-    side_one_output = await cg.get_variable(side_one_config[CONF_OUTPUT])
-    cg.add(var.set_side_one_output(side_one_output))
-    side_one_value_sensor_config = side_one_config[CONF_VALUE_SENSOR]
-    side_one_value_sensor = await sensor.new_sensor(side_one_value_sensor_config)
-    cg.add(var.set_side_one_value_sensor(side_one_value_sensor))
-    side_one_sensor = await binary_sensor.new_binary_sensor(side_one_config)
-    cg.add(var.set_side_one_sensor(side_one_sensor))
+    cg.add(var.set_side_one_output(await cg.get_variable(side_one_config[CONF_OUTPUT])))
+    cg.add(var.set_side_one_value_sensor(await sensor.new_sensor(side_one_config[CONF_VALUE_SENSOR])))
+    cg.add(var.set_side_one_sensor(await binary_sensor.new_binary_sensor(side_one_config)))
 
     side_two_config = config[CONF_SIDE_TWO]
     cg.add(var.set_side_two_name(side_two_config[CONF_STATUS_NAME]))
-    side_two_output = await cg.get_variable(side_two_config[CONF_OUTPUT])
-    cg.add(var.set_side_two_output(side_two_output))
-    side_two_value_sensor_config = side_two_config[CONF_VALUE_SENSOR]
-    side_two_value_sensor = await sensor.new_sensor(side_two_value_sensor_config)
-    cg.add(var.set_side_two_value_sensor(side_two_value_sensor))
-    side_two_sensor = await binary_sensor.new_binary_sensor(side_two_config)
-    cg.add(var.set_side_two_sensor(side_two_sensor))
+    cg.add(var.set_side_two_output(await cg.get_variable(side_two_config[CONF_OUTPUT])))
+    cg.add(var.set_side_two_value_sensor(await sensor.new_sensor(side_two_config[CONF_VALUE_SENSOR])))
+    cg.add(var.set_side_two_sensor(await binary_sensor.new_binary_sensor(side_two_config)))
 
     someone_config = config[CONF_SOMEONE]
     cg.add(var.set_someone_name(someone_config[CONF_STATUS_NAME]))
-    someone_sensor = await binary_sensor.new_binary_sensor(someone_config)
-    cg.add(var.set_someone_sensor(someone_sensor))
+    cg.add(var.set_someone_sensor(await binary_sensor.new_binary_sensor(someone_config)))
 
-    count_config = config[CONF_COUNT]
-    count_sensor = await sensor.new_sensor(count_config)
-    cg.add(var.set_count_sensor(count_sensor))
-
-    status_config = config[CONF_STATUS]
-    status_sensor = await text_sensor.new_text_sensor(status_config)
-    cg.add(var.set_status_sensor(status_sensor))
+    cg.add(var.set_count_sensor(await sensor.new_sensor(config[CONF_COUNT])))
+    cg.add(var.set_status_sensor(await text_sensor.new_text_sensor(config[CONF_STATUS])))

--- a/components/bed_sensor/bed_sensor.cpp
+++ b/components/bed_sensor/bed_sensor.cpp
@@ -12,6 +12,8 @@ void BedSensor::setup() {
     this->side_one_output_->set_state(false);
   if (this->side_two_output_ != nullptr)
     this->side_two_output_->set_state(false);
+  this->combined_name_ =
+      std::string(this->side_one_name_) + " and " + std::string(this->side_two_name_);
 }
 
 void BedSensor::dump_config() {
@@ -23,14 +25,14 @@ void BedSensor::dump_config() {
 void BedSensor::update() {
   if (this->adc_sensor_ == nullptr || this->side_one_output_ == nullptr || this->side_two_output_ == nullptr)
     return;
-  if (this->last_side_updated_ == 2) {
+  if (!this->last_updated_side_one_) {
     this->side_two_output_->set_state(false);
     this->side_one_output_->set_state(true);
     this->adc_sensor_->update();
     this->side_one_value_ = this->adc_sensor_->state;
     ESP_LOGD(TAG, "Side one value: %f", this->side_one_value_);
     this->side_one_value_sensor_->publish_state(this->side_one_value_);
-    this->last_side_updated_ = 1;
+    this->last_updated_side_one_ = true;
   } else {
     this->side_one_output_->set_state(false);
     this->side_two_output_->set_state(true);
@@ -38,7 +40,7 @@ void BedSensor::update() {
     this->side_two_value_ = this->adc_sensor_->state;
     ESP_LOGD(TAG, "Side two value: %f", this->side_two_value_);
     this->side_two_value_sensor_->publish_state(this->side_two_value_);
-    this->last_side_updated_ = 2;
+    this->last_updated_side_one_ = false;
   }
 
   float side_one_percent = (1024 - this->side_one_value_) * 100 / 1024;
@@ -59,21 +61,17 @@ void BedSensor::update() {
   int count = (side_one_in_bed ? 1 : 0) + (side_two_in_bed ? 1 : 0) + (someone_in_bed ? 1 : 0);
   this->count_->publish_state(count);
 
-  std::string status;
   if (count == 0) {
-    status = "Empty";
+    this->status_->publish_state("Empty");
   } else if (count == 2) {
-    status = this->side_one_name_;
-    status += " and ";
-    status += this->side_two_name_;
+    this->status_->publish_state(this->combined_name_);
   } else if (side_one_in_bed) {
-    status = this->side_one_name_;
+    this->status_->publish_state(this->side_one_name_);
   } else if (side_two_in_bed) {
-    status = this->side_two_name_;
+    this->status_->publish_state(this->side_two_name_);
   } else if (someone_in_bed) {
-    status = this->someone_name_;
+    this->status_->publish_state(this->someone_name_);
   }
-  this->status_->publish_state(status);
 }
 
 }  // namespace esphome::bed_sensor

--- a/components/bed_sensor/bed_sensor.h
+++ b/components/bed_sensor/bed_sensor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "esphome/core/component.h"
 
 #include "esphome/components/adc/adc_sensor.h"
@@ -12,24 +14,32 @@ namespace esphome::bed_sensor {
 
 class BedSensor : public PollingComponent {
  public:
-  void set_adc_sensor(adc::ADCSensor *adc_sensor) { adc_sensor_ = adc_sensor; }
+  void set_adc_sensor(adc::ADCSensor *adc_sensor) { this->adc_sensor_ = adc_sensor; }
 
-  void set_side_one_output(output::BinaryOutput *side_one_output) { side_one_output_ = side_one_output; }
-  void set_side_one_name(const char *side_one_name) { side_one_name_ = side_one_name; }
-  void set_side_one_value_sensor(sensor::Sensor *side_one_value_sensor) { side_one_value_sensor_ = side_one_value_sensor; }
-  void set_side_one_sensor(binary_sensor::BinarySensor *side_one_sensor) { side_one_sensor_ = side_one_sensor; }
+  void set_side_one_output(output::BinaryOutput *side_one_output) { this->side_one_output_ = side_one_output; }
+  void set_side_one_name(const char *side_one_name) { this->side_one_name_ = side_one_name; }
+  void set_side_one_value_sensor(sensor::Sensor *side_one_value_sensor) {
+    this->side_one_value_sensor_ = side_one_value_sensor;
+  }
+  void set_side_one_sensor(binary_sensor::BinarySensor *side_one_sensor) {
+    this->side_one_sensor_ = side_one_sensor;
+  }
 
-  void set_side_two_output(output::BinaryOutput *side_two_output) { side_two_output_ = side_two_output; }
-  void set_side_two_name(const char *side_two_name) { side_two_name_ = side_two_name; }
-  void set_side_two_value_sensor(sensor::Sensor *side_two_value_sensor) { side_two_value_sensor_ = side_two_value_sensor; }
-  void set_side_two_sensor(binary_sensor::BinarySensor *side_two_sensor) { side_two_sensor_ = side_two_sensor; }
+  void set_side_two_output(output::BinaryOutput *side_two_output) { this->side_two_output_ = side_two_output; }
+  void set_side_two_name(const char *side_two_name) { this->side_two_name_ = side_two_name; }
+  void set_side_two_value_sensor(sensor::Sensor *side_two_value_sensor) {
+    this->side_two_value_sensor_ = side_two_value_sensor;
+  }
+  void set_side_two_sensor(binary_sensor::BinarySensor *side_two_sensor) {
+    this->side_two_sensor_ = side_two_sensor;
+  }
 
-  void set_someone_sensor(binary_sensor::BinarySensor *someone_in_bed) { someone_in_bed_ = someone_in_bed; }
-  void set_someone_name(const char *someone_name) { someone_name_ = someone_name; }
+  void set_someone_sensor(binary_sensor::BinarySensor *someone_in_bed) { this->someone_in_bed_ = someone_in_bed; }
+  void set_someone_name(const char *someone_name) { this->someone_name_ = someone_name; }
 
-  void set_count_sensor(sensor::Sensor *count) { count_ = count; }
+  void set_count_sensor(sensor::Sensor *count) { this->count_ = count; }
 
-  void set_status_sensor(text_sensor::TextSensor *status) { status_ = status; }
+  void set_status_sensor(text_sensor::TextSensor *status) { this->status_ = status; }
 
   void setup() override;
   void dump_config() override;
@@ -54,7 +64,8 @@ class BedSensor : public PollingComponent {
   sensor::Sensor *count_{nullptr};
   text_sensor::TextSensor *status_{nullptr};
 
-  uint8_t last_side_updated_{2};
+  bool last_updated_side_one_{false};
+  std::string combined_name_;
   float side_one_value_{1024.0f};
   float side_two_value_{1024.0f};
 };


### PR DESCRIPTION
* init.py — Added AUTO_LOAD; removed 8 single-use intermediate variables by inlining
* bed_sensor.h — Added #include <string>; added this-> to all 10 setters; split the two overlong setter lines; replaced uint8_t last_side_updated_{2} with bool last_updated_side_one_{false}; added std::string combined_name_ member
* bed_sensor.cpp — Pre-computes combined_name_ once in setup(); updated last_updated_side_one_ references throughout update(); replaced the std::string status local variable + concatenation with direct publish_state() calls
* README.md — Fixed occupants count range from 0–3 to 0–2