### PR TITLE
Switch pool_controller schedules from 30-minute to 1-hour slots

### DIFF
--- a/.claude/commands/commit_pr.md
+++ b/.claude/commands/commit_pr.md
@@ -1,0 +1,13 @@
+---
+description: Run pre-commit hooks to a clean state, commit, push, open a PR, merge it, and clean up the branch.
+---
+
+Do everything the `commit` command does, then take the change all the way through a merged PR and back to a clean `master`.
+
+1. Follow the `commit` command's steps 1–5 in full: branch check/creation (`f/`/`b/`/`chore/` naming, never commit on `master`), `python -m pre_commit run --all-files` to a clean state, the commit itself (with the `Co-Authored-By: Claude <noreply@anthropic.com>` trailer), and the push (`git push` / `git push -u origin <branch>`). Never skip hooks, never work around a real hook failure.
+2. Open the PR using the `pr-workflow` skill so it follows this repo's established PR conventions (title, body, labels, etc.) rather than reinventing them here.
+3. Merge the PR: this repo only allows squash merges (`allow_squash_merge: true`; `allow_merge_commit`/`allow_rebase_merge` are both `false`), so merge with `gh pr merge <number> --squash`. `master` has no required status checks configured, so the merge should go through immediately — if `gh` reports it can't merge (conflicts, an unexpected required check, etc.), stop and report rather than forcing it. Don't pass `--delete-branch`: the repo already has `delete_branch_on_merge` enabled, so GitHub deletes the remote branch itself on merge.
+4. Switch back to `master`: `git checkout master`.
+5. Sync `master`: `git pull` (should fast-forward cleanly since nothing else is committed directly to `master`).
+6. Delete the now-merged local branch: `git branch -D <branch>` — use `-D` (force), not `-d`. Because the merge was a squash, the local branch's commits aren't literally an ancestor of the new `master` commit, so `-d`'s "already merged" safety check will refuse to delete it even though the change is fully in `master`. Confirm first (`git log master -1` matches the change, `git status` clean) before force-deleting.
+7. Finish with `git status` and `git branch` to confirm you're on an up-to-date `master` with the feature branch gone.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is an [ESPHome](https://esphome.io) configuration repository: YAML device configs plus custom external components (Python codegen + C++) for a collection of home-automation devices (pool controller, HVAC zone control, energy monitors, smart plugs, etc.) that integrate with Home Assistant. It is not an application with a build/test pipeline in the traditional sense — the "build" is ESPHome compiling a device's YAML into firmware, and the "tests" are lint/format checks plus ESPHome's own YAML config validation.
 
-There is no local `esphome` CLI installed in this environment. Compiling and flashing devices happens through the ESPHome Dashboard/Device Builder that owns this config directory (its state files are described below) — don't assume `esphome compile`/`esphome config` are runnable from a shell here.
+Compiling and flashing devices normally happens through the ESPHome Dashboard/Device Builder that owns this config directory (its state files are described below). A local `esphome` CLI is also installed on this Windows machine via `pipx` (isolated from system Python) — useful for `esphome config <file>.yaml` to validate a device's full resolved config without going through Device Builder; see the "ESPHome CLI" section below for details, gotchas, and update instructions.
 
 ## Commands
 
@@ -22,6 +22,18 @@ Individual hooks, if you need to invoke a tool directly instead of via pre-commi
 - `flake8` — additional docstring/style checks, scoped to `components/**/*.py` only (`.flake8`).
 - `yamllint` — all YAML files except `.clang-format`/`.clang-tidy` (`.yamllint`: 2-space indent, no line-length limit, `document-start` disabled).
 - `clang-format` — C/C++ files in `components/**` (`.clang-format`).
+
+### ESPHome CLI
+
+Installed via `pipx install esphome`, which creates its own isolated virtualenv rather than touching system Python packages.
+
+- **Must be installed under Python 3.12+**, not this machine's default Python 3.11 (`C:\Program Files\Python311`). ESPHome 2026.7.0+ requires Python `>=3.12,<3.15`; installing under 3.11 doesn't error, it silently resolves to the newest 3.11-compatible release instead (e.g. 2026.6.5 when 2026.7.2 was current), which can surface as spurious "Platform not found" errors for components added in newer releases. Use the `py -3.12` launcher (or the full interpreter path) when installing/upgrading:
+  ```
+  pipx install --python "C:\Users\<user>\AppData\Local\Programs\Python\Python312\python.exe" esphome
+  ```
+- The `esphome.exe` shim lands in the pipx bin dir (`%USERPROFILE%\.local\bin`), which `pipx ensurepath` adds to the persistent user PATH — new terminals/sessions should resolve `esphome` directly. A shell that was already running before the PATH update won't see it until restarted; fall back to the full venv path (`...\pipx\venvs\esphome\Scripts\esphome.exe` — check `pipx list` for the exact location, it can be nested as `pipx\pipx\venvs\...` depending on how pipx itself was installed) if `esphome` isn't found.
+- To check/upgrade: `pipx upgrade esphome`, or reinstall with the `--python` flag above if it's drifted onto the wrong interpreter.
+- `esphome config <file>.yaml` validates and fully resolves a device config (schema + substitutions + packages) without needing a compile toolchain — much faster than a full `esphome compile` and doesn't require platformio.
 
 ## Git workflow
 
@@ -50,6 +62,8 @@ Components are consumed either from disk (`external_components: - source: {type:
 **Version compatibility tags**: git tags like `2026.7.0` mark commits confirmed compatible with that ESPHome version. `scripts/tag_esphome_version.py` runs as a `post-commit` pre-commit hook (see `default_install_hook_types` / the `tag-esphome-version` local hook in `.pre-commit-config.yaml`) and automates this: it reads the local, gitignored `.esphome/.device-builder-devices.json` (Device Builder state), and if every root-level device yaml has a `deployed_version` whose `deployed_config_hash` matches `expected_config_hash`, it tags HEAD with the lowest such version — unless a tag at or above it already exists. It never pushes the tag; push explicitly (`git push origin <tag>`) or rely on `git config push.followTags true` so a normal `git push` carries it along. Because it's a post-commit hook it can't block a commit — if devices aren't fully represented/up to date yet, it just prints why it skipped.
 
 **Sibling `dev_esphome/` directory** (outside this repo, listed as an additional working directory) is a full checkout of upstream ESPHome core, wired in purely for editor IntelliSense (`python.analysis.extraPaths` / `C_Cpp.default.includePath` in `.vscode/settings.json`, `PYTHONPATH` in `.env`). It is not part of this project — don't make changes there as part of tasks against this repo.
+
+**Sibling `esphome.io/` directory** (outside this repo, also listed as an additional working directory) is a clone of the [esphome/esphome.io](https://github.com/esphome/esphome.io) documentation site (the Astro-based source for the public esphome.io docs), with a `fork` remote at `nuttytree/esphome.io` alongside `origin`. Like `dev_esphome/`, it's a separate project checked out here for reference/IntelliSense — not part of this repo, so don't make changes there as part of tasks against this repo unless explicitly asked to work on the docs site itself.
 
 **Device Builder state files** at the repo root (`.device-builder.json`, `.device-builder-preferences.json`, `.device-builder-peer-link-key.bin`) are machine-generated local state for the ESPHome dashboard/device-builder tool (device MAC addresses, firmware job history, UI prefs) — not meant to be hand-edited.
 

--- a/components/pool_controller/README.md
+++ b/components/pool_controller/README.md
@@ -1,7 +1,7 @@
 # Pool Controller
 
 ## Overview
-Note: This component is a work in progress. I created this component to automate my pool equipment — a primary circulation pump, an auxiliary cleaner pump, and an optional pool heater. The core idea is schedule-based pump control with a fractional runtime model: instead of running a pump continuously for a long window, you configure a `minutes_per_hour` value so the pump cycles on and off proportionally within each half-hour slot. The primary and auxiliary pumps are sequenced so the primary always starts first and stops last, protecting the heater and cleaner from running without water flow. An optional current sensor enables anomaly detection that can fire automations when the pump draws significantly more or less current than its learned baseline.
+Note: This component is a work in progress. I created this component to automate my pool equipment — a primary circulation pump, an auxiliary cleaner pump, and an optional pool heater. The core idea is schedule-based pump control with a fractional runtime model: instead of running a pump continuously for a long window, you configure a `minutes_per_hour` value so the pump cycles on and off proportionally within each hour-long slot. The primary and auxiliary pumps are sequenced so the primary always starts first and stops last, protecting the heater and cleaner from running without water flow. An optional current sensor enables anomaly detection that can fire automations when the pump draws significantly more or less current than its learned baseline.
 
 ## Setup
 Using the [External Components](https://esphome.io/components/external_components.html) feature in ESPHome you can add this component to your devices directly from my GitHub repo.
@@ -73,8 +73,8 @@ Accepts all standard [ESPHome Switch options](https://esphome.io/components/swit
 * **schedules** (Optional, list): Named schedules available for selection. Each schedule has:
   * **name** (Required, string): Unique display name shown in the schedule select entity.
   * **runtimes** (Required, list): One or more time windows. Each runtime has:
-    * **start_time** (Required, time): Window start on the hour or half-hour (e.g. `'6:00'`, `'6:30'`).
-    * **end_time** (Required, time): Window end on the hour or half-hour; use `'24:00'` for midnight end-of-day.
+    * **start_time** (Required, time): Window start on the hour (e.g. `'6:00'`).
+    * **end_time** (Required, time): Window end on the hour; use `'24:00'` for midnight end-of-day.
     * **minutes_per_hour** (Required, int, 1–60): How many minutes out of each 60 the pump should run within this window.
     * **days_of_week** (Optional): Days this runtime applies to (e.g. `MON-FRI`, `SAT,SUN`). Defaults to every day.
 * **current_sensor** (Optional, id): ID of a sensor reporting current draw in amps. Required when `on_anomaly` is configured. When set, turning the switch on always publishes an on state and energizes the output, but the pump's runtime is only accumulated while current confirms the motor is actually running.
@@ -105,7 +105,7 @@ Accepts all standard [ESPHome Water Heater options](https://esphome.io/component
 ## Operation
 
 ### Schedule-based Fractional Runtime
-Each half-hour slot is evaluated independently. Within a slot the pump runs for `minutes_per_hour / 2` minutes (since each slot is 30 minutes), evenly distributed. This lets you approximate variable-speed pump behavior with a single-speed pump by reducing run time during lower-demand periods.
+Each hour-long slot is evaluated independently. Within a slot the pump runs for `minutes_per_hour` minutes, evenly distributed. This lets you approximate variable-speed pump behavior with a single-speed pump by reducing run time during lower-demand periods.
 
 ### Sequenced Startup and Shutdown
 When starting, the primary pump turns on first and auxiliary pumps wait for `sequence_delay` before turning on. When stopping, auxiliary pumps turn off immediately and the primary pump follows after `sequence_delay`. If a pool heater is configured it is turned off before the primary pump during shutdown to avoid running the heater without water flow.

--- a/components/pool_controller/pool_controller.cpp
+++ b/components/pool_controller/pool_controller.cpp
@@ -25,7 +25,7 @@ void PoolController::setup() {
 }
 
 void PoolController::reset_all_pump_runtimes_() {
-  ESP_LOGD(TAG, "Half-hour boundary – resetting pump runtime counters (%02d:%02d)", this->last_check_->hour,
+  ESP_LOGD(TAG, "Hourly boundary – resetting pump runtime counters (%02d:%02d)", this->last_check_->hour,
            this->last_check_->minute);
   if (this->primary_pump_ != nullptr)
     this->primary_pump_->reset_runtime();
@@ -68,13 +68,13 @@ void PoolController::tick_pump_schedule_(PumpSwitch *pump, const ESPTime &now) {
     return;
   }
 
-  const uint16_t slot_start = static_cast<uint16_t>(now.hour) * 60 + (now.minute >= 30 ? 30 : 0);
+  const uint16_t slot_start = static_cast<uint16_t>(now.hour) * 60;
   uint32_t target_seconds = 0;
 
   if (pump->is_builtin_last_schedule()) {
     if (pump == this->primary_pump_) {
-      // "Always": run the full 30-minute window.
-      target_seconds = 60u * 30u;  // 1800 s
+      // "Always": run the full 1-hour window.
+      target_seconds = 60u * 60u;  // 3600 s
     } else {
       // "When X is Running": mirror the primary pump's state.
       if (this->primary_pump_ != nullptr && this->primary_pump_->state) {
@@ -94,19 +94,19 @@ void PoolController::tick_pump_schedule_(PumpSwitch *pump, const ESPTime &now) {
         pump->turn_off();
       return;
     }
-    // Target on-time for this 30-minute window:
-    //   minutes_per_hour / 2 converted to seconds  =  minutes_per_hour * 30
+    // Target on-time for this 1-hour window:
+    //   minutes_per_hour converted to seconds  =  minutes_per_hour * 60
     const ScheduleRuntime *rt = pump->find_active_runtime(slot_start, now.day_of_week);
     if (rt != nullptr && rt->minutes_per_hour > 0)
-      target_seconds = static_cast<uint32_t>(rt->minutes_per_hour) * 30;
+      target_seconds = static_cast<uint32_t>(rt->minutes_per_hour) * 60;
   }
 
   const uint32_t current_runtime = pump->get_runtime_seconds();
 
-  // A full-window target (60 min/hr = 1800 s) means run continuously for the entire
-  // 30-minute slot.  Never turn the pump off because the runtime counter caught up to
-  // the target — the half-hour reset will clear the counter without stopping the pump.
-  const bool full_window = (target_seconds == 60u * 30u);
+  // A full-window target (60 min/hr = 3600 s) means run continuously for the entire
+  // 1-hour slot.  Never turn the pump off because the runtime counter caught up to
+  // the target — the hourly reset will clear the counter without stopping the pump.
+  const bool full_window = (target_seconds == 60u * 60u);
 
   if (!full_window && (target_seconds == 0 || current_runtime >= target_seconds)) {
     // Own schedule says stop — but keep the primary alive if an auxiliary still needs it.
@@ -170,9 +170,9 @@ bool PoolController::any_auxiliary_needs_primary_(uint16_t slot_start, uint8_t d
     const ScheduleRuntime *rt = aux->find_active_runtime(slot_start, day_of_week);
     if (rt == nullptr || rt->minutes_per_hour == 0)
       continue;
-    const uint32_t target = static_cast<uint32_t>(rt->minutes_per_hour) * 30;
+    const uint32_t target = static_cast<uint32_t>(rt->minutes_per_hour) * 60;
     // A full-window auxiliary (60 min/hr) always needs the primary for the entire slot.
-    if (target == 60u * 30u)
+    if (target == 60u * 60u)
       return true;
     if (aux->get_runtime_seconds() < target)
       return true;
@@ -207,12 +207,12 @@ void PoolController::loop() {
       return;
     }
 
-    // Walk second-by-second so no :00/:30 boundary is ever missed.
+    // Walk second-by-second so no :00 boundary is ever missed.
     while (true) {
       this->last_check_->increment_second();
       if (*this->last_check_ >= now)
         break;
-      if (this->last_check_->second == 0 && this->last_check_->minute % 30 == 0)
+      if (this->last_check_->second == 0 && this->last_check_->minute == 0)
         this->reset_all_pump_runtimes_();
       this->tick_all_pump_schedules_(*this->last_check_);
     }
@@ -220,7 +220,7 @@ void PoolController::loop() {
 
   this->last_check_ = now;
 
-  if (now.second == 0 && now.minute % 30 == 0)
+  if (now.second == 0 && now.minute == 0)
     this->reset_all_pump_runtimes_();
   this->tick_all_pump_schedules_(now);
 }

--- a/components/pool_controller/pool_controller.h
+++ b/components/pool_controller/pool_controller.h
@@ -40,7 +40,7 @@ class PoolController : public Component {
   PoolHeater *pool_heater_{
       nullptr};  ///< Optional pool heater — turned off before the primary pump during sequenced shutdown.
 
-  /// Mirrors CronTrigger::last_check_ — used for time-drift-safe :00/:30 detection.
+  /// Mirrors CronTrigger::last_check_ — used for time-drift-safe :00 detection.
   optional<ESPTime> last_check_;
 
   /// Sequenced shutdown state: auxiliaries off immediately, primary off after sequence_delay_ms_.
@@ -53,7 +53,7 @@ class PoolController : public Component {
   void tick_pump_schedule_(PumpSwitch *pump, const ESPTime &now);
 
   /// Returns true if any auxiliary pump has a user-defined schedule with remaining
-  /// runtime in the given half-hour slot — used to keep the primary pump running
+  /// runtime in the given hour-long slot — used to keep the primary pump running
   /// even when its own schedule would otherwise turn it off.
   bool any_auxiliary_needs_primary_(uint16_t slot_start, uint8_t day_of_week) const;
 

--- a/components/pool_controller/pump_switch.h
+++ b/components/pool_controller/pump_switch.h
@@ -17,8 +17,8 @@ namespace pool_controller {
 
 /// A single time window within a schedule.
 struct ScheduleRuntime {
-  uint16_t start_minute;     ///< Minutes since midnight (0-1410)
-  uint16_t end_minute;       ///< Minutes since midnight (30-1440, 1440 = 24:00)
+  uint16_t start_minute;     ///< Minutes since midnight (0-1380)
+  uint16_t end_minute;       ///< Minutes since midnight (60-1440, 1440 = 24:00)
   uint8_t minutes_per_hour;  ///< Minutes to run per hour within this window
   uint8_t days_of_week;      ///< Bitmask: bit0=Sun, bit1=Mon, ..., bit6=Sat; 0x7F = every day
 };
@@ -65,7 +65,7 @@ class PumpSwitch : public switch_::Switch, public Component {
     schedules_.back().runtimes.push_back({start_minute, end_minute, minutes_per_hour, days_of_week});
   }
 
-  /// Returns total pump runtime in seconds since the last half-hour reset.
+  /// Returns total pump runtime in seconds since the last hourly reset.
   uint32_t get_runtime_seconds() const {
     if (this->runtime_start_ms_ != 0) {
       return this->runtime_seconds_ + (millis_64() - this->runtime_start_ms_) / 1000;
@@ -150,7 +150,7 @@ class PumpSwitch : public switch_::Switch, public Component {
  protected:
   friend class PoolController;
 
-  /// Resets accumulated runtime to zero. Called by PoolController at :00 and :30.
+  /// Resets accumulated runtime to zero. Called by PoolController at :00.
   void reset_runtime();
 
   /// Call this in write_state() before setting the output so runtime is tracked correctly.
@@ -165,7 +165,7 @@ class PumpSwitch : public switch_::Switch, public Component {
   void set_unexpected_flow_(bool detected);
 
   /// Returns the ScheduleRuntime from the active user-defined schedule that covers
-  /// [slot_start_minute, slot_start_minute+30), for the given day_of_week (1=Sun..7=Sat).
+  /// [slot_start_minute, slot_start_minute+60), for the given day_of_week (1=Sun..7=Sat).
   /// Returns nullptr if no matching runtime exists or the active schedule is not a user schedule.
   const ScheduleRuntime *find_active_runtime(uint16_t slot_start_minute, uint8_t day_of_week) const;
 
@@ -173,7 +173,7 @@ class PumpSwitch : public switch_::Switch, public Component {
   std::vector<Schedule> schedules_;
 
   size_t active_schedule_idx_{0};  ///< Index into schedules_ for the currently active schedule.
-  uint32_t runtime_seconds_ = 0;   ///< Accumulated runtime (seconds) since last half-hour reset.
+  uint32_t runtime_seconds_ = 0;   ///< Accumulated runtime (seconds) since last hourly reset.
   uint64_t runtime_start_ms_ = 0;  ///< millis_64() when pump last turned on; 0 when off.
   uint64_t last_off_ms_ = 0;       ///< millis_64() when pump last turned off; used for 5-min cooldown.
   uint64_t turned_on_ms_ = 0;      ///< millis_64() when pump last physically turned on; used for turn-on sequencing.

--- a/components/pool_controller/schema/schedule.py
+++ b/components/pool_controller/schema/schedule.py
@@ -25,29 +25,29 @@ def _time_to_str(time_val):
     return f"{time_val[CONF_HOUR]}:{time_val[CONF_MINUTE]:02d}"
 
 
-def _validate_half_hour(time_val):
-    """Validate that a time_of_day value falls on the hour or half-hour."""
-    if time_val[CONF_MINUTE] not in (0, 30):
+def _validate_on_hour(time_val):
+    """Validate that a time_of_day value falls on the hour."""
+    if time_val[CONF_MINUTE] != 0:
         raise cv.Invalid(
-            f"Minutes must be 00 or 30 (on the hour or half-hour), got {time_val[CONF_MINUTE]:02d}"
+            f"Minutes must be 00 (on the hour), got {time_val[CONF_MINUTE]:02d}"
         )
     return time_val
 
 
-HALF_HOUR_TIME = cv.All(cv.time_of_day, _validate_half_hour)
+ON_HOUR_TIME = cv.All(cv.time_of_day, _validate_on_hour)
 
 _MIDNIGHT_END = {CONF_HOUR: 24, CONF_MINUTE: 0, CONF_SECOND: 0}
 
 
-def _validate_half_hour_end_time(value):
-    """Like HALF_HOUR_TIME but also accepts 24:00 to mean end of day."""
+def _validate_on_hour_end_time(value):
+    """Like ON_HOUR_TIME but also accepts 24:00 to mean end of day."""
     value = cv.string(value)
     if value in ("24:00", "24:0"):
         return _MIDNIGHT_END
-    return _validate_half_hour(cv.time_of_day(value))
+    return _validate_on_hour(cv.time_of_day(value))
 
 
-HALF_HOUR_END_TIME = _validate_half_hour_end_time
+ON_HOUR_END_TIME = _validate_on_hour_end_time
 
 ALL_DAYS = set(range(1, 8))
 
@@ -105,8 +105,8 @@ def _validate_no_runtime_overlaps(schedule):
 RUNTIME_SCHEMA = cv.All(
     cv.Schema(
         {
-            cv.Required(CONF_START_TIME): HALF_HOUR_TIME,
-            cv.Required(CONF_END_TIME): HALF_HOUR_END_TIME,
+            cv.Required(CONF_START_TIME): ON_HOUR_TIME,
+            cv.Required(CONF_END_TIME): ON_HOUR_END_TIME,
             cv.Required(CONF_MINUTES_PER_HOUR): cv.All(
                 cv.int_, cv.Range(min=1, max=60)
             ),

--- a/pool.yaml
+++ b/pool.yaml
@@ -16,9 +16,6 @@ external_components:
       path: ./components
     components: [pool_controller, pzem6l24]
 
-  # - source: github://esphome/esphome@dev
-  #   components: [waveshare_io_ch32v003]
-
 esphome:
   on_boot:
     then:


### PR DESCRIPTION
Changes the pool_controller fractional-runtime scheduling granularity from 30-minute slots to 1-hour slots: `minutes_per_hour` now applies directly to a full hour instead of being halved per half-hour window, and schedule `start_time`/`end_time` must land on the hour instead of the hour or half-hour. Runtime counters reset at :00 only (no longer at :00 and :30), and the second-by-second drift-safe boundary walk, auxiliary-needs-primary check, and README/docs were all updated to match.

Also:
- Documents the local pipx-installed `esphome` CLI in CLAUDE.md (Python 3.12 requirement, PATH gotchas, upgrade instructions) and the sibling `esphome.io/` docs checkout.
- Drops a stale commented-out `waveshare_io_ch32v003` external_components entry from pool.yaml.