### PR TITLE
Resume pump state after restart; fix anomaly baseline reset and flow gating

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is an [ESPHome](https://esphome.io) configuration repository: YAML device configs plus custom external components (Python codegen + C++) for a collection of home-automation devices (pool controller, HVAC zone control, energy monitors, smart plugs, etc.) that integrate with Home Assistant. It is not an application with a build/test pipeline in the traditional sense — the "build" is ESPHome compiling a device's YAML into firmware, and the "tests" are lint/format checks plus ESPHome's own YAML config validation.
 
-Compiling and flashing devices normally happens through the ESPHome Dashboard/Device Builder that owns this config directory (its state files are described below). A local `esphome` CLI is also installed on this Windows machine via `pipx` (isolated from system Python) — useful for `esphome config <file>.yaml` to validate a device's full resolved config without going through Device Builder; see the "ESPHome CLI" section below for details, gotchas, and update instructions.
+Compiling and flashing devices normally happens through the ESPHome Dashboard/Device Builder that owns this config directory (its state files are described below). A local `esphome` CLI is also installed on this Windows machine via `pipx` (isolated from system Python) — useful for `esphome config <file>.yaml` to validate a device's full resolved config without going through Device Builder; see the "ESPHome CLI" section below for details, gotchas, and update instructions. Full local compiles are possible too, but need one-time machine setup — see "Compiling locally".
 
 ## Commands
 
@@ -34,6 +34,26 @@ Installed via `pipx install esphome`, which creates its own isolated virtualenv 
 - The `esphome.exe` shim lands in the pipx bin dir (`%USERPROFILE%\.local\bin`), which `pipx ensurepath` adds to the persistent user PATH — new terminals/sessions should resolve `esphome` directly. A shell that was already running before the PATH update won't see it until restarted; fall back to the full venv path (`...\pipx\venvs\esphome\Scripts\esphome.exe` — check `pipx list` for the exact location, it can be nested as `pipx\pipx\venvs\...` depending on how pipx itself was installed) if `esphome` isn't found.
 - To check/upgrade: `pipx upgrade esphome`, or reinstall with the `--python` flag above if it's drifted onto the wrong interpreter.
 - `esphome config <file>.yaml` validates and fully resolves a device config (schema + substitutions + packages) without needing a compile toolchain — much faster than a full `esphome compile` and doesn't require platformio.
+
+### Compiling locally (ESP-IDF toolchain)
+
+`esphome config` needs none of this; `esphome compile` needs all of it. Compiling normally happens inside the Device Builder/Docker container, and the `.esphome/build/<device>` directories in this repo were produced *there* (paths rooted at `/config/...`), so a Windows build can't reuse them — it fails with `The current CMakeCache.txt directory ... is different than the directory ... where CMakeCache.txt was created`. A host compile therefore always starts from a fresh build directory, and needs the two setup steps below.
+
+**1. Put the ESP-IDF toolchain on a short path.** Windows' default `MAX_PATH` is 260 characters and the IDF toolchain nests ~245 characters below its tools directory, so the default location (`%LOCALAPPDATA%\esphome\Cache\idf`) overflows it. The failure is cryptic — `fatal error: bits/c++config.h: No such file or directory`, or `cannot execute 'as'` — though ESPHome does print a warning naming the problem first. Either fix works:
+
+- Enable long path support (needs elevation, then a reboot):
+  ```
+  Set-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' LongPathsEnabled 1
+  ```
+- Or point ESPHome at a short prefix, which it maps straight to `IDF_TOOLS_PATH`. This is what the current machine does (`LongPathsEnabled` is `0` there, and the prefix is `C:\eh`):
+  ```
+  [Environment]::SetEnvironmentVariable('ESPHOME_ESP_IDF_PREFIX','C:\eh','User')
+  ```
+  On a fresh machine ESPHome downloads roughly 6 GB into that prefix on the first compile. To migrate an existing install instead of re-downloading, move `%LOCALAPPDATA%\esphome\Cache\idf` to the new prefix, then delete `tools\`, `penvs\` and `idf-env.json` inside it — those re-extract from the `dist\` archive cache that moves along with them.
+
+**2. Build to a local drive, not the UNC share.** This repo lives on `\\nas\docker\esphome\config`, and `packages/device_base.yaml` sets `build_path: ./build/${device_id}`, which resolves onto that share. `cmd.exe` cannot use a UNC path as a working directory, so ninja's *link* step runs from `C:\Windows` and fails with `ld.exe: cannot open output file ...: Permission denied`. The compile steps succeed first, which makes this read as a linker bug rather than a path problem. Override `build_path` to a local path (e.g. `C:/eh/bld/<name>`) when compiling from Windows. Source files can stay on the share — gcc handles UNC paths fine; only the working directory is the problem.
+
+To compile-check a component without disturbing the container's build caches, copy the device YAML to a throwaway `device_id` with a local `build_path`, compile that copy, then delete both the scratch YAML and its build directory. A full IDF build takes roughly 10–15 minutes.
 
 ## Git workflow
 

--- a/components/pool_controller/README.md
+++ b/components/pool_controller/README.md
@@ -64,6 +64,8 @@ pool_controller:
 * **auxiliary_pumps** (Optional, list): Zero or more auxiliary pumps (e.g. cleaner, fill valve). See [Auxiliary Pump](#auxiliary-pump) below.
 * **sequence_delay** (Optional, Time, default: `2s`): How long to wait between primary and auxiliary pump state changes during sequenced startup and shutdown.
 * **disable_pumps_sensor** (Optional, id): ID of a binary sensor that, when active, immediately shuts all pumps off and prevents any pump from turning on.
+* **state_save_interval** (Optional, Time, default: `5min`): How often each pump's operating state is written to flash so a restart can resume where it left off. This bounds how much accumulated runtime a sudden power loss can lose. See [Restart Recovery](#restart-recovery).
+* **max_resume_age** (Optional, Time, default: `15min`): How stale a saved state may be and still be resumed. Beyond this the outage is treated as extended, the saved state is discarded, and pumps start cold. See [Restart Recovery](#restart-recovery).
 * **pool_heater** (Optional): Configuration for an optional pool heater. See [Pool Heater](#pool-heater) below.
 
 ### Primary Pump
@@ -82,12 +84,12 @@ Accepts all standard [ESPHome Switch options](https://esphome.io/components/swit
 * **no_current_binary_sensor** (Optional): Problem binary sensor, automatically added whenever `current_sensor` is configured. Turns on whenever the switch is commanded on but no current is detected (e.g. a manual override switch has the pump physically off). Supports all standard [ESPHome Binary Sensor options](https://esphome.io/components/binary_sensor/index.html); defaults to `<pump name> No Current`.
 * **anomaly_detection_switch** (Optional): A Switch entity, created whenever `current_sensor` is configured, that enables or disables anomaly detection at runtime. Supports all standard [ESPHome Switch options](https://esphome.io/components/switch/index.html); restores to on by default and defaults to `<pump name> Anomaly Detection`.
 * **anomaly_status_binary_sensor** (Optional): Problem binary sensor, created whenever `current_sensor` is configured, that turns on when a current-draw anomaly is currently active. Supports all standard [ESPHome Binary Sensor options](https://esphome.io/components/binary_sensor/index.html); defaults to `<pump name> Anomaly Status`.
-* **anomaly_baseline_reset_button** (Optional): A Button entity, created whenever `current_sensor` is configured, that discards the learned current baseline and begins relearning when pressed. Ignored (with a warning logged) while `flow_loss_binary_sensor` is active, so a reset can't lock in a baseline contaminated by an in-progress flow-loss fault. Supports all standard [ESPHome Button options](https://esphome.io/components/button/index.html); defaults to `<pump name> Reset Anomaly Baseline`.
+* **anomaly_baseline_reset_button** (Optional): A Button entity, created whenever `current_sensor` is configured, that discards the learned current baseline (steady state, drift, variance, startup inrush) and clears any latched anomaly. The press is never refused and can be made at any time; relearning does not start immediately but at the pump's next turn-on, so the new baseline is always built from a complete run — see [Baseline Reset](#baseline-reset). Supports all standard [ESPHome Button options](https://esphome.io/components/button/index.html); defaults to `<pump name> Reset Anomaly Baseline`.
 * **anomaly_reason_text_sensor** (Optional): Text sensor, created whenever `current_sensor` is configured, publishing the reason string of the most recent anomaly — lets a single `anomaly_status_binary_sensor` on-state be disambiguated in the UI/history. Supports all standard [ESPHome Text Sensor options](https://esphome.io/components/text_sensor/index.html); defaults to `<pump name> Anomaly Reason`.
 * **anomaly_threshold_pct** (Optional, int 1–100, default: `10`): Percentage deviation from baseline required to trigger an anomaly event.
 * **learning_samples** (Optional, int 10–10000, default: `200`): Number of steady-state current samples to collect before the baseline is locked.
 * **on_anomaly** (Optional, automation): Automation triggered when an anomaly is detected. The trigger variable `x` is a string describing the anomaly: `CURRENT_HIGH`, `CURRENT_LOW`, `NO_STARTUP_SPIKE`, `BASELINE_DRIFT` (either direction — rising suggests bearing wear, falling suggests prime/flow loss), or `VARIANCE_SPIKE` (current spread has grown well beyond its learned baseline, often the earliest sign of trouble).
-* **flow_sensor** (Optional, id): ID of a binary sensor that detects water flow. If no `current_sensor` is configured, the pump's runtime is only accumulated while flow is actually detected. If a `current_sensor` is configured, runtime is controlled by current instead (see above), and the pump is additionally shut down if current confirms the motor is running but flow is lost for longer than `flow_timeout`. Without a `current_sensor`, no-flow alone never shuts the pump down — a manual override switch physically holding the pump off would otherwise look identical to a real no-flow fault.
+* **flow_sensor** (Optional, id): ID of a binary sensor that detects water flow. If no `current_sensor` is configured, the pump's runtime is only accumulated while flow is actually detected. If a `current_sensor` is configured, runtime is controlled by current instead (see above), and the pump is additionally shut down if current confirms the motor is running but flow is lost for longer than `flow_timeout`. Without a `current_sensor`, no-flow alone never shuts the pump down — a manual override switch physically holding the pump off would otherwise look identical to a real no-flow fault. When both sensors are configured, flow also gates anomaly statistics — see [Current-based Anomaly Detection](#current-based-anomaly-detection).
 * **flow_timeout** (Optional, Time, default: `2s`): How long flow must be absent (while a current sensor confirms the motor is running) before the pump is shut down.
 * **flow_loss_binary_sensor** (Optional): Problem binary sensor, automatically added whenever both `current_sensor` and `flow_sensor` are configured. Latches on when the pump is shut down due to lost flow, and only clears once the pump is on, current confirms the motor is running, and flow is detected again. Supports all standard [ESPHome Binary Sensor options](https://esphome.io/components/binary_sensor/index.html); defaults to `<pump name> Flow Loss`.
 * **unexpected_flow_binary_sensor** (Optional): Problem binary sensor, automatically added whenever `flow_sensor` is configured. Turns on when flow is detected while the pump is commanded off for longer than `flow_timeout` (e.g. a stuck valve, a neighboring pump pushing water through this branch, or a manual override running the pump), and clears as soon as flow stops or the pump turns on. Supports all standard [ESPHome Binary Sensor options](https://esphome.io/components/binary_sensor/index.html); defaults to `<pump name> Unexpected Flow`.
@@ -110,11 +112,42 @@ Each hour-long slot is evaluated independently. Within a slot the pump runs for 
 ### Sequenced Startup and Shutdown
 When starting, the primary pump turns on first and auxiliary pumps wait for `sequence_delay` before turning on. When stopping, auxiliary pumps turn off immediately and the primary pump follows after `sequence_delay`. If a pool heater is configured it is turned off before the primary pump during shutdown to avoid running the heater without water flow.
 
+### Restart Recovery
+`millis()` restarts at zero on boot and says nothing about how long the device was down, so without persisted state a restart looks identical to a cold first start. Each pump therefore writes a small timestamped snapshot — accumulated runtime, the hour slot that runtime belongs to, and when it last stopped — every `state_save_interval` and on every start and stop.
+
+On the first tick after the clock is valid, and before any schedule decision is made, each pump applies its snapshot:
+
+* **Snapshot older than `max_resume_age`** — treated as an extended outage. It is discarded and the pump starts cold: zero runtime and a full minimum off-time from boot.
+* **Runtime** carries over only when the snapshot belongs to the hour slot we are now in. If a slot boundary passed while the device was down, the runtime resets to zero — that is the hourly reset nobody was running to perform. Without it, a stale count would be measured against the new slot's target and could suppress the run for that whole hour.
+* **Minimum off-time.** If the pump was running when the snapshot was taken, the stop was the restart itself rather than the end of a duty cycle, so there is nothing to protect against and the schedule may bring it straight back up. If it was already off, the off-time it has served — including the outage, which the wall clock covers — is credited against the minimum, and only the remainder is waited out.
+
+The snapshot always includes the in-flight portion of a run in progress, so an unexpected restart loses at most `state_save_interval` worth of runtime rather than the entire run.
+
+#### Flash Wear
+Snapshots are committed to flash immediately rather than being left to the global `preferences: flash_write_interval`. That interval is meant for chatty components; leaving these writes to it would let an unrelated global setting decide how much runtime a restart can recover. Writes are instead bounded by `state_save_interval` plus pump start/stop events — at the 5-minute default, under 300 writes a day, which is comfortably within the endurance of the wear-levelled NVS partition. Raise `state_save_interval` to trade resume accuracy for fewer writes.
+
 ### Pump Disable Sensor
 When `disable_pumps_sensor` is active (on), all pumps are turned off immediately and no pump is allowed to turn on until the sensor clears. This is useful for wiring in an external interlock (e.g. a cover sensor or maintenance switch).
 
 ### Current-based Anomaly Detection
 When enabled, the component learns the pump's normal steady-state current draw over `learning_samples` samples. After learning is complete, any reading that deviates by more than `anomaly_threshold_pct` percent triggers the `on_anomaly` automation with a string describing the event. A separate startup-inrush baseline is maintained to avoid false positives during the motor startup window.
+
+Each run is split into a 15 s startup window, during which the inrush peak is captured, and a steady-state phase, which feeds the baseline while learning and is compared against it afterwards.
+
+#### What Counts as a Valid Sample
+Current confirms the motor is energized, but not that the pump is doing useful work, so a `flow_sensor` — when configured — decides whether a sample means anything:
+
+* **Steady-state samples** are only taken while flow is present. A pump that is spinning but moving no water draws an atypical current that would otherwise be learned as normal or misread as a current anomaly; the flow-loss watchdog is what reports that condition. The out-of-band debounce streak is dropped across a no-flow gap so it can never span one.
+* **The startup inrush peak** is only folded into the startup reference if flow was established at some point during the startup window. Flow is never required *at* the moment of inrush — a pump needs a moment to prime — but a start that never moved water is discarded (logged as a warning) rather than averaged in, and cannot raise `NO_STARTUP_SPIKE` either.
+
+With no `flow_sensor` configured there is nothing better to go on, so current alone gates capture, exactly as before.
+
+#### Baseline Reset
+Pressing `anomaly_baseline_reset_button` discards everything learned — steady-state EMA, drift EMA, variance accumulators, startup inrush reference and run count — clears the latched anomaly status and the alert cooldown, and persists the cleared baseline immediately.
+
+Capture is then *armed rather than started*. Nothing is sampled until the pump next turns on, at which point learning begins with the startup window still ahead of it. This holds no matter when the button is pressed: a run already in progress has no startup window left to observe, and sampling it would produce a baseline with no inrush reference and a steady-state figure taken from a partially-observed run. The cost is that a pump running continuously (the `Always` schedule, with nothing to cycle it off) relearns nothing until its next off/on cycle.
+
+Relearning then follows the normal path: the first run seeds the startup reference, `NO_STARTUP_SPIKE` checks resume once three starts have accumulated, and the steady-state baseline locks after `learning_samples` valid samples.
 
 ### Flow Sensor Protection
 If a `flow_sensor` is configured and reports no flow for longer than `flow_timeout` while the pump output is commanded on, the pump is shut down to protect against dry-running or blockage.

--- a/components/pool_controller/__init__.py
+++ b/components/pool_controller/__init__.py
@@ -8,6 +8,8 @@ from .const import (
     CONF_AUXILIARY_PUMPS,
     CONF_SEQUENCE_DELAY,
     CONF_DISABLE_PUMPS_SENSOR,
+    CONF_STATE_SAVE_INTERVAL,
+    CONF_MAX_RESUME_AGE,
 )
 from .schema.types import PoolController
 from .schema.pump import (
@@ -38,6 +40,13 @@ CONFIG_SCHEMA = cv.Schema(
             CONF_SEQUENCE_DELAY, default="2s"
         ): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_DISABLE_PUMPS_SENSOR): cv.use_id(binary_sensor.BinarySensor),
+        cv.Optional(
+            CONF_STATE_SAVE_INTERVAL, default="5min"
+        ): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_MAX_RESUME_AGE, default="15min"): cv.All(
+            cv.positive_time_period_seconds,
+            cv.Range(min=cv.TimePeriod(seconds=1)),
+        ),
         cv.Optional(CONF_POOL_HEATER): POOL_HEATER_SCHEMA,
     }
 ).extend(cv.COMPONENT_SCHEMA)
@@ -52,6 +61,8 @@ async def to_code(config):
 
     delay_ms = config[CONF_SEQUENCE_DELAY]
     cg.add(var.set_sequence_delay(delay_ms))
+    cg.add(var.set_state_save_interval(config[CONF_STATE_SAVE_INTERVAL]))
+    cg.add(var.set_max_resume_age(config[CONF_MAX_RESUME_AGE]))
 
     disable_sensor = None
     if CONF_DISABLE_PUMPS_SENSOR in config:
@@ -61,7 +72,7 @@ async def to_code(config):
     # Primary pump
     primary_config = config[CONF_PRIMARY_PUMP]
     primary = cg.new_Pvariable(primary_config[CONF_ID])
-    await pump_to_code(primary, primary_config, delay_ms, disable_sensor)
+    await pump_to_code(primary, primary_config, delay_ms, disable_sensor, rtc)
     cg.add(var.set_primary_pump(primary))
     await schedule_select_to_code(primary, primary_config, "Always")
 
@@ -70,7 +81,7 @@ async def to_code(config):
     aux_pumps = []
     for aux_config in config.get(CONF_AUXILIARY_PUMPS, []):
         aux = cg.new_Pvariable(aux_config[CONF_ID])
-        await pump_to_code(aux, aux_config, delay_ms, disable_sensor)
+        await pump_to_code(aux, aux_config, delay_ms, disable_sensor, rtc)
         cg.add(aux.set_primary_pump(primary))
         await schedule_select_to_code(
             aux, aux_config, f"When {primary_name} is Running"

--- a/components/pool_controller/const.py
+++ b/components/pool_controller/const.py
@@ -10,6 +10,8 @@ CONF_MINUTES_PER_HOUR = "minutes_per_hour"
 CONF_SCHEDULE_SELECT = "schedule_select"
 CONF_SEQUENCE_DELAY = "sequence_delay"
 CONF_DISABLE_PUMPS_SENSOR = "disable_pumps_sensor"
+CONF_STATE_SAVE_INTERVAL = "state_save_interval"
+CONF_MAX_RESUME_AGE = "max_resume_age"
 
 CONF_CURRENT_SENSOR = "current_sensor"
 CONF_ANOMALY_DETECTION_SWITCH = "anomaly_detection_switch"

--- a/components/pool_controller/pool_controller.cpp
+++ b/components/pool_controller/pool_controller.cpp
@@ -24,6 +24,25 @@ void PoolController::setup() {
   }
 }
 
+void PoolController::restore_pump_states_(const ESPTime &now) {
+  if (this->primary_pump_ != nullptr)
+    this->primary_pump_->restore_run_state(now, this->max_resume_age_s_);
+  for (auto *aux : this->auxiliary_pumps_)
+    aux->restore_run_state(now, this->max_resume_age_s_);
+  this->next_state_save_ms_ = millis_64() + this->state_save_interval_ms_;
+}
+
+void PoolController::save_pump_states_if_due_() {
+  const uint64_t now_ms = millis_64();
+  if (now_ms < this->next_state_save_ms_)
+    return;
+  this->next_state_save_ms_ = now_ms + this->state_save_interval_ms_;
+  if (this->primary_pump_ != nullptr)
+    this->primary_pump_->save_run_state();
+  for (auto *aux : this->auxiliary_pumps_)
+    aux->save_run_state();
+}
+
 void PoolController::reset_all_pump_runtimes_() {
   ESP_LOGD(TAG, "Hourly boundary – resetting pump runtime counters (%02d:%02d)", this->last_check_->hour,
            this->last_check_->minute);
@@ -157,7 +176,7 @@ bool PoolController::primary_is_ready_for_aux_() const {
   if (this->primary_pump_ == nullptr || !this->primary_pump_->state)
     return false;
   // Auxiliaries may start only after the primary has been running for sequence_delay_ms_.
-  return (millis_64() - this->primary_pump_->turned_on_ms_) >= this->sequence_delay_ms_;
+  return this->primary_pump_->get_running_for_ms() >= this->sequence_delay_ms_;
 }
 
 bool PoolController::any_auxiliary_needs_primary_(uint16_t slot_start, uint8_t day_of_week) const {
@@ -187,6 +206,14 @@ void PoolController::loop() {
   ESPTime now = this->rtc_->now();
   if (!now.is_valid())
     return;
+
+  // First valid time since boot: resume from the last saved state before any schedule decision
+  // is made, so runtime counters and minimum off-times reflect what was happening before the
+  // restart rather than a cold start.
+  if (!this->state_restored_) {
+    this->state_restored_ = true;
+    this->restore_pump_states_(now);
+  }
 
   // Mirrors the CronTrigger::loop() pattern to handle NTP time jumps correctly.
   static constexpr int MAX_TIMESTAMP_DRIFT = 900;  // seconds
@@ -223,6 +250,10 @@ void PoolController::loop() {
   if (now.second == 0 && now.minute == 0)
     this->reset_all_pump_runtimes_();
   this->tick_all_pump_schedules_(now);
+
+  // Snapshot last, so a save landing on an hour boundary records the post-reset counters
+  // against the new slot rather than the old count against the new slot number.
+  this->save_pump_states_if_due_();
 }
 
 }  // namespace pool_controller

--- a/components/pool_controller/pool_controller.h
+++ b/components/pool_controller/pool_controller.h
@@ -30,6 +30,10 @@ class PoolController : public Component {
   void set_sequence_delay(uint32_t delay_ms) { this->sequence_delay_ms_ = delay_ms; }
   void set_disable_pumps_sensor(binary_sensor::BinarySensor *sensor) { this->disable_pumps_sensor_ = sensor; }
   void set_pool_heater(PoolHeater *heater) { this->pool_heater_ = heater; }
+  /// How often each pump's operating state is written to flash. Default: 5 minutes.
+  void set_state_save_interval(uint32_t interval_ms) { this->state_save_interval_ms_ = interval_ms; }
+  /// How stale a saved state may be and still be resumed after a restart. Default: 15 minutes.
+  void set_max_resume_age(uint32_t max_age_s) { this->max_resume_age_s_ = max_age_s; }
 
  protected:
   PrimaryPumpSwitch *primary_pump_{nullptr};
@@ -47,6 +51,18 @@ class PoolController : public Component {
   bool primary_turn_off_pending_{false};
   uint64_t primary_turn_off_at_ms_{0};
   uint32_t sequence_delay_ms_{2000};  ///< Configurable delay (ms) between primary and auxiliary pump state changes.
+
+  // ── Restart resume ─────────────────────────────────────────────────────────
+  bool state_restored_{false};                    ///< True once the boot-time restore has run.
+  uint64_t next_state_save_ms_{0};                ///< millis_64() of the next periodic snapshot.
+  uint32_t state_save_interval_ms_{5u * 60000u};  ///< Interval between periodic snapshots.
+  uint32_t max_resume_age_s_{15u * 60u};          ///< Snapshots older than this are discarded on restore.
+
+  /// Applies every pump's saved state. Runs once, as soon as the clock is valid and before any
+  /// schedule tick, so resumed runtimes are in place before anything acts on them.
+  void restore_pump_states_(const ESPTime &now);
+  /// Writes every pump's state if the snapshot interval has elapsed.
+  void save_pump_states_if_due_();
 
   void reset_all_pump_runtimes_();
   void tick_all_pump_schedules_(const ESPTime &now);

--- a/components/pool_controller/pool_heater.cpp
+++ b/components/pool_controller/pool_heater.cpp
@@ -120,8 +120,7 @@ void PoolHeater::update_temperature_() {
   if (this->primary_pump_ == nullptr || !this->primary_pump_->state)
     return;
 
-  const uint64_t on_ms = millis_64() - this->primary_pump_->get_turned_on_ms();
-  if (on_ms < 15000u)
+  if (this->primary_pump_->get_running_for_ms() < 15000u)
     return;
 
   const float raw = this->temperature_sensor_->state;

--- a/components/pool_controller/pump_anomaly.cpp
+++ b/components/pool_controller/pump_anomaly.cpp
@@ -20,14 +20,18 @@ void PumpSwitch::reset_anomaly_baseline() {
   this->startup_processed_ = false;
   this->oob_streak_ = 0;
   this->spread_ema_ = 0.0f;
-  // A mid-run reset shouldn't inherit timing from before the reset: clear the cooldown so
-  // the next real anomaly isn't silently suppressed, and clear turned_on_ms_ so a stale
-  // turn-on time (from before the reset) can't be mistaken for this run's start.
+  this->run_flow_confirmed_ = false;
+  // Clear the cooldown so the next real anomaly isn't silently suppressed by an alert that
+  // fired against the baseline we just discarded.
   this->last_anomaly_ms_ = 0;
-  this->turned_on_ms_ = 0;
   this->set_anomaly_detected_(false);
+  // Capture is armed, not started. A run already in progress has no startup window left to
+  // observe, and its inrush peak (if any) belongs to the discarded baseline — so nothing is
+  // sampled until the pump next turns on and a complete run is available. turned_on_ms_ is
+  // deliberately left alone; it is shared with heater and auxiliary-pump sequencing.
+  this->awaiting_fresh_start_ = true;
   this->anomaly_pref_.save(&this->anomaly_baseline_);
-  ESP_LOGI(TAG, "'%s' anomaly baseline reset; capturing new samples", this->get_name().c_str());
+  ESP_LOGI(TAG, "'%s' anomaly baseline reset; capture begins at the next pump start", this->get_name().c_str());
 #endif
 }
 
@@ -52,6 +56,11 @@ static constexpr float EMA_LEARN_ALPHA = 0.1f;
 static constexpr float EMA_DRIFT_ALPHA = 0.001f;
 
 void PumpSwitch::tick_anomaly_() {
+  // A baseline reset arms capture but doesn't start it: wait for the next turn-on so the new
+  // baseline is built from a whole run, startup window included. track_runtime() clears this.
+  if (this->awaiting_fresh_start_)
+    return;
+
   const float current = this->current_sensor_->state;
   if (std::isnan(current) || current < 0.0f)
     return;
@@ -62,19 +71,36 @@ void PumpSwitch::tick_anomaly_() {
   const bool in_startup = (run_ms < ANOMALY_STARTUP_WINDOW_MS);
 
   if (in_startup) {
-    // Track the inrush peak; do not update the steady-state EMA yet.
+    // Track the inrush peak; do not update the steady-state EMA yet. Flow is only noted here,
+    // never required — a pump takes a moment to prime, so the whole window is allowed for it.
     if (current > this->startup_peak_current_)
       this->startup_peak_current_ = current;
+    if (this->has_flow_sensor() && this->flow_sensor_->state)
+      this->run_flow_confirmed_ = true;
     return;
   }
 
   // Startup window just finished — evaluate the captured inrush peak once.
   if (!this->startup_processed_) {
     this->startup_processed_ = true;
-    this->process_startup_peak_();
+    if (this->startup_capture_valid_()) {
+      this->process_startup_peak_();
+    } else {
+      // The motor drew its inrush but never moved water, so this peak says nothing about a
+      // healthy start. Discard it rather than averaging it into the startup reference.
+      ESP_LOGW(TAG, "'%s' startup peak %.3fA discarded: no flow established during startup", this->get_name().c_str(),
+               this->startup_peak_current_);
+    }
   }
 
   // ── Steady-state phase ──────────────────────────────────────────
+  // Flow gate: with a flow sensor present, statistics are only meaningful while water is
+  // actually moving. Drop the debounce streak so a no-flow gap can't count toward a trip.
+  if (!this->stats_capture_allowed_()) {
+    this->oob_streak_ = 0;
+    return;
+  }
+
   if (!this->baseline_locked_) {
     // Learning phase: build EMA baseline toward lock.
     if (this->sample_count_ == 0) {
@@ -222,13 +248,12 @@ void PumpAnomalyStatusBinarySensor::setup() {
   this->publish_initial_state(false);
 }
 
+/// Always resets — the press is never refused. Contamination of the new baseline is prevented
+/// by the capture rules themselves (a complete run is required, and with a flow sensor, flow
+/// must be present), not by second-guessing when the button may be pressed.
 void PumpAnomalyResetButton::press_action() {
   if (this->pump_ == nullptr)
     return;
-  if (this->pump_->is_flow_loss_active()) {
-    ESP_LOGW(TAG, "'%s' anomaly baseline reset ignored: flow loss is active", this->pump_->get_name().c_str());
-    return;
-  }
   this->pump_->reset_anomaly_baseline();
 }
 

--- a/components/pool_controller/pump_switch.cpp
+++ b/components/pool_controller/pump_switch.cpp
@@ -10,19 +10,32 @@ namespace pool_controller {
 
 static const char *const TAG = "pool_controller.switch";
 
+// Minimum time the pump must stay off between duty cycles, protecting the motor from short-cycling.
+static constexpr uint32_t MIN_OFF_TIME_MS = 5u * 60u * 1000u;
+// Length of a runtime slot; runtime targets are expressed per 1-hour slot.
+static constexpr uint32_t SLOT_SECONDS = 60u * 60u;
+
+// A preference's storage key is the entity's object-id hash XORed with the `version` argument,
+// and the stored size is *not* part of the key. A pump owns two preferences, so both need a
+// distinct non-zero version or they share one key and silently overwrite each other — load()
+// then fails on the size mismatch and whichever wrote last is the only one that survives.
+// Zero is reserved: it is what switch_::Switch's own restore-mode preference uses.
+static constexpr uint32_t RUN_STATE_PREF_VERSION = 0x504D5253u;  // 'PMRS'
+static constexpr uint32_t ANOMALY_PREF_VERSION = 0x504D414Eu;    // 'PMAN'
+
 void PumpSwitch::dump_config() { LOG_SWITCH("", "Pool Controller Pump", this); }
 
 void PumpSwitch::setup() {
-  this->runtime_pref_ = this->make_entity_preference<uint32_t>();
-  if (this->runtime_pref_.load(&this->runtime_seconds_)) {
-    ESP_LOGD(TAG, "Restored runtime %" PRIu32 "s from flash", this->runtime_seconds_);
-  } else {
-    this->runtime_seconds_ = 0;
-  }
+  this->run_state_pref_ = this->make_entity_preference<PumpRunState>(RUN_STATE_PREF_VERSION);
+  if (!this->run_state_pref_.load(&this->saved_run_state_))
+    this->saved_run_state_ = PumpRunState();
+    // The snapshot is deliberately not applied here. Deciding whether it is still worth trusting
+    // needs a valid wall clock, which isn't available this early in boot, so PoolController calls
+    // restore_run_state() once time is valid. Until then the pump behaves as if starting cold.
 
 #ifdef USE_SENSOR
   if (this->current_sensor_ != nullptr) {
-    this->anomaly_pref_ = this->make_entity_preference<AnomalyBaseline>();
+    this->anomaly_pref_ = this->make_entity_preference<AnomalyBaseline>(ANOMALY_PREF_VERSION);
     if (this->anomaly_pref_.load(&this->anomaly_baseline_)) {
       this->sample_count_ = this->anomaly_baseline_.sample_count;
       this->baseline_locked_ = (this->sample_count_ >= this->learning_samples_);
@@ -36,8 +49,9 @@ void PumpSwitch::setup() {
 
   this->set_anomaly_detected_(false);
   this->turn_off();
-  // Enforce the 5-minute cooldown from boot — we don't know the previous pump state.
-  this->last_off_ms_ = millis_64();
+  // Hold the full minimum off-time from boot. restore_run_state() relaxes this if the saved
+  // snapshot shows the pump was mid-run, or credits off-time already served.
+  this->can_turn_on_at_ms_ = millis_64() + MIN_OFF_TIME_MS;
 }
 
 void PumpSwitch::reset_runtime() {
@@ -46,8 +60,88 @@ void PumpSwitch::reset_runtime() {
     this->runtime_start_ms_ = millis_64();
   }
   this->runtime_seconds_ = 0;
-  this->runtime_pref_.save(&this->runtime_seconds_);
+  this->save_run_state();
   ESP_LOGD(TAG, "Runtime counter reset");
+}
+
+void PumpSwitch::save_run_state() {
+  if (this->rtc_ == nullptr)
+    return;
+  const ESPTime now = this->rtc_->now();
+  if (!now.is_valid())
+    return;
+
+  PumpRunState state{};
+  state.saved_utc = static_cast<uint32_t>(now.timestamp);
+  state.slot_hour = state.saved_utc / SLOT_SECONDS;
+  // get_runtime_seconds() folds in the portion of the current run not yet accumulated, so a
+  // crash mid-run loses only the time since the last snapshot rather than the whole run.
+  state.runtime_seconds = this->get_runtime_seconds();
+
+  if (this->runtime_start_ms_ != 0) {
+    state.off_since_utc = 0;  // Running: restore reads this as "the only stop was the restart".
+  } else {
+    // Off, but with no recorded stop time — the pump has not run yet, or it stopped before the
+    // clock was valid. Stamp now rather than leaving 0, which restore would misread as "was
+    // running" and let the pump start with no minimum off-time at all. Under-estimating how
+    // long it has been off is the safe direction: it can only lengthen that wait, never skip it.
+    if (this->last_off_utc_ == 0)
+      this->last_off_utc_ = state.saved_utc;
+    state.off_since_utc = this->last_off_utc_;
+  }
+
+  this->saved_run_state_ = state;
+  this->run_state_pref_.save(&state);
+  // Commit now rather than leaving it to the global flash_write_interval. A snapshot still
+  // sitting in RAM when the power drops is a snapshot that never existed, and that interval is
+  // set for chatty components — it would otherwise silently decide how much runtime a restart
+  // can recover, regardless of state_save_interval. Writes here are deliberate and bounded by
+  // state_save_interval plus pump start/stop events.
+  global_preferences->sync();
+}
+
+void PumpSwitch::restore_run_state(const ESPTime &now, uint32_t max_age_s) {
+  const PumpRunState &state = this->saved_run_state_;
+  if (state.saved_utc == 0) {
+    ESP_LOGD(TAG, "'%s' no saved state to resume from", this->get_name().c_str());
+    return;
+  }
+
+  const uint32_t now_utc = static_cast<uint32_t>(now.timestamp);
+  if (now_utc < state.saved_utc) {
+    ESP_LOGW(TAG, "'%s' saved state is timestamped in the future — ignoring", this->get_name().c_str());
+    return;
+  }
+
+  const uint32_t age_s = now_utc - state.saved_utc;
+  if (age_s > max_age_s) {
+    ESP_LOGI(TAG, "'%s' saved state is %" PRIu32 "s old (limit %" PRIu32 "s) — starting cold", this->get_name().c_str(),
+             age_s, max_age_s);
+    return;
+  }
+
+  // Runtime only carries over within the same hour slot. A slot boundary crossed while the
+  // device was down is an hourly reset nobody was running to perform: without this the stale
+  // count would be compared against the new slot's target and suppress the run entirely.
+  const uint32_t slot_hour = now_utc / SLOT_SECONDS;
+  this->runtime_seconds_ = (slot_hour == state.slot_hour) ? state.runtime_seconds : 0;
+
+  // Minimum off-time. If the pump was running when the snapshot was taken, the stop was the
+  // restart itself rather than the end of a duty cycle — there is no short-cycling to protect
+  // against, so let the schedule bring it straight back up. Otherwise credit the off-time
+  // already served, which the wall clock covers across the outage.
+  uint32_t remaining_ms = 0;
+  if (state.off_since_utc != 0) {
+    this->last_off_utc_ = state.off_since_utc;
+    const uint32_t off_for_s = (now_utc > state.off_since_utc) ? now_utc - state.off_since_utc : 0;
+    if (off_for_s < MIN_OFF_TIME_MS / 1000)
+      remaining_ms = MIN_OFF_TIME_MS - off_for_s * 1000;
+  }
+  this->can_turn_on_at_ms_ = millis_64() + remaining_ms;
+
+  ESP_LOGI(TAG, "'%s' resumed from state %" PRIu32 "s old: runtime %" PRIu32 "s%s, may start in %" PRIu32 "s",
+           this->get_name().c_str(), age_s, this->runtime_seconds_,
+           (slot_hour == state.slot_hour) ? "" : " (new slot, reset)", remaining_ms / 1000);
 }
 
 void PumpSwitch::track_runtime(bool new_state) {
@@ -58,11 +152,24 @@ void PumpSwitch::track_runtime(bool new_state) {
     this->startup_peak_current_ = 0.0f;
     this->startup_processed_ = false;
     this->oob_streak_ = 0;
+    this->run_flow_confirmed_ = false;
+    // This is the clean start a pending baseline reset was waiting for: capture may resume,
+    // and it now begins at a real turn-on with the startup window still ahead of it.
+    this->awaiting_fresh_start_ = false;
+    this->last_off_utc_ = 0;
+    // Snapshot the start immediately: a restart moments from now needs to know the pump was
+    // mid-run, which is what lets it resume without waiting out the minimum off-time.
+    this->save_run_state();
   } else if (!new_state && this->runtime_start_ms_ != 0) {
     this->runtime_seconds_ += (millis_64() - this->runtime_start_ms_) / 1000;
     this->runtime_start_ms_ = 0;
-    this->runtime_pref_.save(&this->runtime_seconds_);
-    this->last_off_ms_ = millis_64();
+    this->can_turn_on_at_ms_ = millis_64() + MIN_OFF_TIME_MS;
+    if (this->rtc_ != nullptr) {
+      const ESPTime off_at = this->rtc_->now();
+      if (off_at.is_valid())
+        this->last_off_utc_ = static_cast<uint32_t>(off_at.timestamp);
+    }
+    this->save_run_state();
     // Deliberately NOT clearing anomaly_detected_ here: turning off is not evidence the
     // problem is resolved. Once tripped, the flag stays latched across the off period and
     // into subsequent runs until tick_anomaly_()'s in-spec hysteresis check (current back

--- a/components/pool_controller/pump_switch.h
+++ b/components/pool_controller/pump_switch.h
@@ -4,10 +4,12 @@
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
 #include "esphome/core/string_ref.h"
+#include "esphome/core/time.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/output/binary_output.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/time/real_time_clock.h"
 #ifdef USE_SENSOR
 #include "esphome/components/sensor/sensor.h"
 #endif
@@ -27,6 +29,17 @@ struct ScheduleRuntime {
 struct Schedule {
   StringRef name;
   std::vector<ScheduleRuntime> runtimes;
+};
+
+/// Snapshot of a pump's operating state, persisted periodically and on every state change so
+/// that a restart can resume mid-slot instead of starting over. Everything here is wall-clock
+/// based: millis_64() restarts at zero on boot and says nothing about how long the device was
+/// down, which is exactly what the restore decision needs to know.
+struct PumpRunState {
+  uint32_t saved_utc{0};        ///< Unix time this snapshot was taken. 0 = never saved.
+  uint32_t slot_hour{0};        ///< Hours since the Unix epoch, naming the 1-hour slot runtime_seconds belongs to.
+  uint32_t runtime_seconds{0};  ///< Runtime accumulated within that slot, including the then-in-flight portion.
+  uint32_t off_since_utc{0};    ///< Unix time the pump last stopped; 0 if it was still running when saved.
 };
 
 /// Persisted baseline data for current-draw anomaly detection.
@@ -58,6 +71,9 @@ class PumpSwitch : public switch_::Switch, public Component {
   void dump_config() override;
 
   void set_output(output::BinaryOutput *output) { output_ = output; }
+
+  /// Wall clock, used to timestamp persisted state so a restart can tell how long it was down.
+  void set_rtc(time::RealTimeClock *rtc) { this->rtc_ = rtc; }
 
   void add_schedule(const char *name) { schedules_.push_back({StringRef(name), {}}); }
   void add_runtime_to_last_schedule(uint16_t start_minute, uint16_t end_minute, uint8_t minutes_per_hour,
@@ -104,7 +120,10 @@ class PumpSwitch : public switch_::Switch, public Component {
   /// Optional text sensor publishing the reason string ("CURRENT_HIGH", "BASELINE_DRIFT", etc.)
   /// of the most recent anomaly, so a single `on` state can be disambiguated.
   void set_anomaly_reason_sensor(text_sensor::TextSensor *sensor) { this->anomaly_reason_sensor_ = sensor; }
-  /// Reset the stored anomaly baseline and force new sample learning.
+  /// Discards the stored anomaly baseline and arms capture of a brand new one. Learning does
+  /// not resume immediately: the next *complete* pump run — full startup window followed by
+  /// steady state — is what gets captured, so the new baseline never inherits a partial view
+  /// of a run that was already underway when the reset happened. Safe to call at any time.
   void reset_anomaly_baseline();
 
   // ── Current-based state ────────────────────────────────────────────────────
@@ -132,20 +151,19 @@ class PumpSwitch : public switch_::Switch, public Component {
   /// ("Always" for PrimaryPumpSwitch, "When X is Running" for AuxiliaryPumpSwitch).
   bool is_builtin_last_schedule() const { return this->active_schedule_idx_ == this->schedules_.size() + 1; }
 
-  /// Returns true when the pump has been off for at least 5 minutes (minimum off-time before restart).
-  bool can_turn_on() const { return (millis_64() - this->last_off_ms_) >= (5u * 60u * 1000u); }
+  /// Returns true when the pump's minimum off-time has elapsed and it may be started.
+  /// Expressed as a deadline rather than "time since last off" so that boot, where millis_64()
+  /// starts near zero and there is no meaningful "last off", is representable.
+  bool can_turn_on() const { return millis_64() >= this->can_turn_on_at_ms_; }
 
   /// Returns true when the disable-pumps sensor is configured and currently active.
   bool is_disabled() const { return this->disable_pumps_sensor_ != nullptr && this->disable_pumps_sensor_->state; }
 
-  /// Returns true when the flow-loss problem sensor is configured and currently latched.
-  /// Used to refuse an anomaly baseline reset while flow loss is in progress, so the
-  /// captured baseline doesn't get contaminated by abnormal current draw.
-  bool is_flow_loss_active() const { return this->flow_loss_sensor_ != nullptr && this->flow_loss_sensor_->state; }
-
-  /// Returns the millis_64() timestamp when the pump last physically turned on.
-  /// Used by PoolHeater to decide when 15 s of pump-on time has elapsed.
-  uint64_t get_turned_on_ms() const { return this->turned_on_ms_; }
+  /// Returns how long the pump has been physically running, or 0 if it has not been confirmed
+  /// running since boot. Callers must not compute this from turned_on_ms_ themselves: that field
+  /// is 0 until the first confirmed turn-on, and `millis_64() - 0` reads as "running forever",
+  /// which would satisfy every elapsed-time gate on the first start after a restart.
+  uint64_t get_running_for_ms() const { return this->turned_on_ms_ == 0 ? 0 : millis_64() - this->turned_on_ms_; }
 
  protected:
   friend class PoolController;
@@ -156,6 +174,18 @@ class PumpSwitch : public switch_::Switch, public Component {
   /// Call this in write_state() before setting the output so runtime is tracked correctly.
   void track_runtime(bool new_state);
   void set_anomaly_detected_(bool detected);
+
+  /// Persists the current operating state with a wall-clock timestamp. No-op until the clock is
+  /// valid: an untimestamped snapshot cannot be aged on restore, which makes it worse than none.
+  /// Called on every start/stop and periodically by PoolController.
+  void save_run_state();
+
+  /// Applies the snapshot loaded in setup(), if it is still worth trusting. Called once by
+  /// PoolController as soon as the clock is valid and before the first schedule tick, so a
+  /// resumed runtime is in place before anything decides whether the pump should be running.
+  /// `max_age_s` is the outage length beyond which the snapshot is discarded and the pump
+  /// starts cold.
+  void restore_run_state(const ESPTime &now, uint32_t max_age_s);
 
   /// Re-evaluates the no-current problem sensor from current `state`/`motor_running_`.
   void update_no_current_();
@@ -171,16 +201,19 @@ class PumpSwitch : public switch_::Switch, public Component {
 
   output::BinaryOutput *output_ = nullptr;
   std::vector<Schedule> schedules_;
+  time::RealTimeClock *rtc_{nullptr};  ///< Wall clock; timestamps persisted state.
 
-  size_t active_schedule_idx_{0};  ///< Index into schedules_ for the currently active schedule.
-  uint32_t runtime_seconds_ = 0;   ///< Accumulated runtime (seconds) since last hourly reset.
-  uint64_t runtime_start_ms_ = 0;  ///< millis_64() when pump last turned on; 0 when off.
-  uint64_t last_off_ms_ = 0;       ///< millis_64() when pump last turned off; used for 5-min cooldown.
-  uint64_t turned_on_ms_ = 0;      ///< millis_64() when pump last physically turned on; used for turn-on sequencing.
+  size_t active_schedule_idx_{0};   ///< Index into schedules_ for the currently active schedule.
+  uint32_t runtime_seconds_ = 0;    ///< Accumulated runtime (seconds) since last hourly reset.
+  uint64_t runtime_start_ms_ = 0;   ///< millis_64() when pump last turned on; 0 when off.
+  uint64_t can_turn_on_at_ms_ = 0;  ///< millis_64() deadline before which the pump may not be started.
+  uint32_t last_off_utc_ = 0;       ///< Unix time the pump last stopped; 0 while running. Persisted.
+  uint64_t turned_on_ms_ = 0;       ///< millis_64() when pump last physically turned on; used for turn-on sequencing.
   uint32_t sequence_delay_ms_ = 2000;  ///< Delay (ms) between primary and auxiliary pump state changes.
   binary_sensor::BinarySensor *disable_pumps_sensor_{
-      nullptr};                       ///< Optional sensor that turns off pumps and blocks turn-ons when active.
-  ESPPreferenceObject runtime_pref_;  ///< Persists runtime_seconds_ across reboots.
+      nullptr};                         ///< Optional sensor that turns off pumps and blocks turn-ons when active.
+  ESPPreferenceObject run_state_pref_;  ///< Persists PumpRunState across reboots.
+  PumpRunState saved_run_state_{};      ///< Snapshot read in setup(), applied later by restore_run_state().
 
   // ── Anomaly detection state ────────────────────────────────────────────────
   bool enable_anomaly_detection_{false};
@@ -203,6 +236,11 @@ class PumpSwitch : public switch_::Switch, public Component {
   bool anomaly_detected_{false};      ///< Latched true once tripped; persists across pump off periods and into
                                       ///< subsequent runs, only clearing once tick_anomaly_() confirms in-spec
                                       ///< recovery. Turning the pump off is not, on its own, evidence of recovery.
+  bool awaiting_fresh_start_{false};  ///< Set by reset_anomaly_baseline(); suppresses all capture until the next
+                                      ///< pump start, so learning always begins from a complete run rather than
+                                      ///< from the middle of whatever run was in progress at reset time.
+  bool run_flow_confirmed_{false};    ///< True once flow has been observed during this run's startup window;
+                                      ///< only meaningful when a flow sensor is configured.
   ESPPreferenceObject anomaly_pref_;  ///< Persists AnomalyBaseline across reboots.
   binary_sensor::BinarySensor *anomaly_status_sensor_{nullptr};
   text_sensor::TextSensor *anomaly_reason_sensor_{nullptr};  ///< Last anomaly reason string (diagnostic).
@@ -237,6 +275,18 @@ class PumpSwitch : public switch_::Switch, public Component {
 
   /// Returns true when a flow sensor is configured for this pump.
   bool has_flow_sensor() const { return this->flow_sensor_ != nullptr; }
+
+  /// Whether anomaly statistics may be captured at this instant.
+  /// With a flow sensor, current draw alone isn't enough — a pump that is spinning but moving
+  /// no water draws an atypical current that must not be folded into the baseline, so capture
+  /// requires water actually moving. Without one, current is the only evidence available and
+  /// the caller has already confirmed the motor is drawing it (motor_running_).
+  bool stats_capture_allowed_() const { return !this->has_flow_sensor() || this->flow_sensor_->state; }
+
+  /// Whether this run's inrush peak is worth folding into the startup reference. With a flow
+  /// sensor, only a start that actually got water moving counts; a motor that spun up against
+  /// a closed valve or lost prime produces a peak that would poison the reference.
+  bool startup_capture_valid_() const { return !this->has_flow_sensor() || this->run_flow_confirmed_; }
 
 #ifdef USE_SENSOR
   /// Samples the current sensor at 1 Hz: updates motor_running_, runtime tracking, the

--- a/components/pool_controller/schema/pump.py
+++ b/components/pool_controller/schema/pump.py
@@ -203,13 +203,14 @@ AUX_PUMP_SCHEMA = cv.All(
 # ── Codegen helpers ────────────────────────────────────────────────────────────
 
 
-async def pump_to_code(var, pump_config, delay_ms, disable_sensor):
+async def pump_to_code(var, pump_config, delay_ms, disable_sensor, rtc):
     """Register a pump switch and emit all its configuration calls."""
     await esphome_switch.register_switch(var, pump_config)
     await cg.register_component(var, pump_config)
 
     out = await cg.get_variable(pump_config[CONF_OUTPUT])
     cg.add(var.set_output(out))
+    cg.add(var.set_rtc(rtc))
     cg.add(var.set_sequence_delay(delay_ms))
 
     if disable_sensor is not None:


### PR DESCRIPTION
After a restart the controller had no idea what had been happening. `millis()` starts at zero on boot and says nothing about how long the device was down, so a restart was indistinguishable from a cold first start: the pump sat out a full 5-minute minimum off-time before it could start even if it had been running seconds earlier, and the runtime counter was only persisted on turn-off, so an unexpected restart mid-run lost the whole run and the pump then ran past its target for the hour. Worse in the other direction, a restart that spanned an hour boundary restored the *previous* hour's runtime with nothing to reset it, so a stale count got measured against the new slot's target and could suppress that hour's run entirely.

Separately, the anomaly baseline reset button (#82) was refused while flow loss was active, and a mid-run press restarted learning from the middle of whatever run was in progress — no startup window left to observe, so the new baseline had no inrush reference. Flow was being used to decide whether the button was allowed rather than whether a sample was meaningful, which is backwards: current confirms the motor is energized, not that the pump is moving water.

Changes:

- Persist a timestamped `PumpRunState` snapshot per pump (runtime, the hour slot it belongs to, and when it last stopped) every `state_save_interval` and on every start/stop. The snapshot includes the in-flight portion of a run in progress, so a crash loses at most one interval rather than the whole run.
- Apply it on the first tick after the clock is valid, before any schedule decision. Runtime carries over within the same hour slot and resets across one; a pump that was mid-run resumes without waiting out the minimum off-time (the stop *was* the restart), and one that was already off is credited for the off-time it served, outage included. Snapshots older than `max_resume_age` are discarded and the pump starts cold.
- Make `can_turn_on()` a deadline rather than "time since last off", so boot — where `millis_64()` is near zero and there is no meaningful last-off — is representable.
- Add `state_save_interval` (default `5min`) and `max_resume_age` (default `15min`) to the `pool_controller:` block.
- Never refuse the baseline reset button; drop the flow-loss guard added in #82. Reset now arms capture rather than starting it, so relearning always begins at the next turn-on with a full startup window ahead of it, whenever the button is pressed.
- Use flow to gate sampling instead: steady-state samples are only taken while water is moving, and an inrush peak is only folded into the startup reference if flow was established during the startup window. Flow is never required *at* the moment of inrush, since a pump needs a moment to prime. With no flow sensor, current alone gates capture as before.

Three bugs surfaced along the way:

- `runtime_pref_` and `anomaly_pref_` shared one NVS key. Preference keys are `object_id_hash ^ version` and the stored size is not part of the key, so both defaulting to `version = 0` meant the last writer won and the other's `load()` failed on the size mismatch — at most one of the two ever restored. Both now use distinct non-zero versions. **This discards existing learned anomaly baselines once on upgrade**; they were never persisting reliably anyway.
- `turned_on_ms_` is 0 at boot, so `millis_64() - turned_on_ms_` read as "running forever". On the first start after a restart that let auxiliaries skip the `sequence_delay` wait and let the heater accept a temperature reading before the pump had circulated for 15 s. Replaced with `get_running_for_ms()`, which returns 0 when no turn-on has been recorded.
- Snapshots commit with an explicit `global_preferences->sync()` instead of being batched by the global `flash_write_interval` (`10min` in `device_base.yaml`), which would otherwise have decided how much runtime a restart could recover regardless of `state_save_interval`. Bounded by `state_save_interval` plus start/stop events — under 300 writes a day at the default, well within the wear-levelled NVS partition.

Also documents the local ESP-IDF toolchain setup needed to compile from Windows (short IDF prefix to dodge the 260-char path limit, local `build_path` because `cmd.exe` can't use a UNC working directory) in `CLAUDE.md`, and updates the component README throughout.

Verified with `esphome compile` on an ESP32-S3 build of `pool.yaml`: clean, no new warnings from any touched file.
