### PR TITLE
Run clang-tidy in CI, matching upstream ESPHome's check list

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,221 @@
+---
+Checks: >-
+  *,
+  -abseil-*,
+  -altera-*,
+  -android-*,
+  -boost-*,
+  -bugprone-derived-method-shadowing-base-method,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-invalid-enum-default-initialization,
+  -bugprone-multi-level-implicit-pointer-conversion,
+  -bugprone-narrowing-conversions,
+  -bugprone-tagged-union-member-count,
+  -bugprone-signed-char-misuse,
+  -bugprone-switch-missing-default-case,
+  -cert-dcl50-cpp,
+  -cert-err33-c,
+  -cert-err58-cpp,
+  -cert-int09-c,
+  -cert-oop57-cpp,
+  -cert-str34-c,
+  -clang-analyzer-optin.core.EnumCastOutOfRange,
+  -clang-analyzer-optin.cplusplus.UninitializedObject,
+  -clang-analyzer-osx.*,
+  -clang-analyzer-security.ArrayBound,
+  -clang-diagnostic-delete-abstract-non-virtual-dtor,
+  -clang-diagnostic-delete-non-abstract-non-virtual-dtor,
+  -clang-diagnostic-deprecated-declarations,
+  -clang-diagnostic-ignored-optimization-argument,
+  -clang-diagnostic-missing-designated-field-initializers,
+  -clang-diagnostic-missing-field-initializers,
+  -clang-diagnostic-shadow-field,
+  -clang-diagnostic-unused-const-variable,
+  -clang-diagnostic-unused-parameter,
+  -clang-diagnostic-vla-cxx-extension,
+  -concurrency-*,
+  -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-avoid-const-or-ref-data-members,
+  -cppcoreguidelines-avoid-do-while,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-init-variables,
+  -cppcoreguidelines-macro-to-enum,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-missing-std-forward,
+  -cppcoreguidelines-narrowing-conversions,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-prefer-member-initializer,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-const-cast,
+  -cppcoreguidelines-pro-type-cstyle-cast,
+  -cppcoreguidelines-pro-type-member-init,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-type-static-cast-downcast,
+  -cppcoreguidelines-pro-type-union-access,
+  -cppcoreguidelines-pro-type-vararg,
+  -cppcoreguidelines-rvalue-reference-param-not-moved,
+  -cppcoreguidelines-special-member-functions,
+  -cppcoreguidelines-use-default-member-init,
+  -cppcoreguidelines-use-enum-class,
+  -cppcoreguidelines-virtual-class-destructor,
+  -fuchsia-default-arguments-calls,
+  -fuchsia-default-arguments-declarations,
+  -fuchsia-multiple-inheritance,
+  -fuchsia-overloaded-operator,
+  -fuchsia-statically-constructed-objects,
+  -google-build-using-namespace,
+  -google-explicit-constructor,
+  -google-readability-braces-around-statements,
+  -google-readability-casting,
+  -google-readability-namespace-comments,
+  -google-readability-todo,
+  -google-runtime-references,
+  -hicpp-*,
+  -llvm-else-after-return,
+  -llvm-header-guard,
+  -llvm-include-order,
+  -llvm-prefer-static-over-anonymous-namespace,
+  -llvm-qualified-auto,
+  -llvm-use-ranges,
+  -llvmlibc-*,
+  -misc-const-correctness,
+  -misc-include-cleaner,
+  -misc-multiple-inheritance,
+  -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
+  -misc-override-with-different-visibility,
+  -misc-unused-parameters,
+  -misc-use-anonymous-namespace,
+  -misc-use-internal-linkage,
+  -modernize-avoid-bind,
+  -modernize-avoid-variadic-functions,
+  -modernize-avoid-c-arrays,
+  -modernize-avoid-c-style-cast,
+  -modernize-macro-to-enum,
+  -modernize-return-braced-init-list,
+  -modernize-type-traits,
+  -modernize-use-auto,
+  -modernize-use-constraints,
+  -modernize-use-default-member-init,
+  -modernize-use-designated-initializers,
+  -modernize-use-equals-default,
+  -modernize-use-integer-sign-comparison,
+  -modernize-use-nodiscard,
+  -modernize-use-nullptr,
+  -modernize-use-ranges,
+  -modernize-use-trailing-return-type,
+  -mpi-*,
+  -objc-*,
+  -performance-enum-size,
+  -portability-avoid-pragma-once,
+  -portability-template-virtual-member-function,
+  -readability-ambiguous-smartptr-reset-call,
+  -readability-avoid-nested-conditional-operator,
+  -readability-container-data-pointer,
+  -readability-convert-member-functions-to-static,
+  -readability-else-after-return,
+  -readability-enum-initial-value,
+  -readability-function-cognitive-complexity,
+  -readability-implicit-bool-conversion,
+  -readability-isolate-declaration,
+  -readability-magic-numbers,
+  -readability-make-member-function-const,
+  -readability-math-missing-parentheses,
+  -readability-named-parameter,
+  -readability-redundant-casting,
+  -readability-redundant-inline-specifier,
+  -readability-redundant-member-init,
+  -readability-redundant-parentheses,
+  -readability-redundant-typename,
+  -readability-uppercase-literal-suffix,
+  -readability-use-anyofallof,
+  -readability-use-std-min-max,
+  -readability-use-concise-preprocessor-directives,
+WarningsAsErrors: '*'
+FormatStyle:     google
+CheckOptions:
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-runtime-int.TypeSuffix
+    value:           '_t'
+  - key:             llvm-namespace-comment.ShortNamespaceLines
+    value:           '10'
+  - key:             llvm-namespace-comment.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             modernize-make-unique.MakeSmartPtrFunction
+    value:           'make_unique'
+  - key:             modernize-make-unique.MakeSmartPtrFunctionHeader
+    value:           'esphome/core/helpers.h'
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           2
+  - key:             readability-identifier-naming.LocalVariableCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ClassCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.StructCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.EnumCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.EnumConstantCase
+    value:           'UPPER_CASE'
+  - key:             readability-identifier-naming.StaticConstantCase
+    value:           'UPPER_CASE'
+  - key:             readability-identifier-naming.StaticVariableCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.GlobalConstantCase
+    value:           'UPPER_CASE'
+  - key:             readability-identifier-naming.ParameterCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.PrivateMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.PrivateMemberSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.PrivateMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.PrivateMethodSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.ClassMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ClassMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMemberSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.FunctionCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ClassMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMethodSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.VirtualMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.VirtualMethodSuffix
+    value:           ''
+  - key:             readability-qualified-auto.AddConstToQualified
+    value:           0
+  - key:             readability-identifier-length.MinimumVariableNameLength
+    value:           0
+  - key:             readability-identifier-length.MinimumParameterNameLength
+    value:           0
+  - key:             readability-identifier-length.MinimumLoopCounterNameLength
+    value:           0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,12 @@ jobs:
           done
           exit $status
 
-  # Compiling proves the custom C++ components in components/ still build. The
-  # matrix is the smallest set of devices that covers every custom component,
-  # across both platforms -- the components are compiled per-platform, so an
-  # esp32 build says nothing about the esp8266 ones.
+  # Compiling proves the custom C++ components in components/ still build, and
+  # the build then feeds clang-tidy (see scripts/clang_tidy.py -- it needs a
+  # compiled build's flags and generated defines.h). The matrix is the smallest
+  # set of devices that covers every custom component, across both platforms --
+  # the components are compiled per-platform, so an esp32 build says nothing
+  # about the esp8266 ones.
   esphome-compile:
     name: compile ${{ matrix.device }}
     runs-on: ubuntu-latest
@@ -108,3 +110,12 @@ jobs:
         run: python scripts/generate_ci_secrets.py
       - name: Compile ${{ matrix.device }}
         run: esphome compile devices/${{ matrix.device }}.yaml
+      # Same clang-tidy version and .clang-tidy check list as upstream ESPHome,
+      # so the components here are held to the same C++ rules. Pinned because a
+      # new clang-tidy adds checks, which would fail unrelated PRs.
+      - name: Install clang-tidy
+        run: pip install clang-tidy==22.1.8
+      - name: Register clang-tidy problem matcher
+        run: echo "::add-matcher::.github/workflows/matchers/clang-tidy.json"
+      - name: Run clang-tidy on the components ${{ matrix.device }} builds
+        run: python scripts/clang_tidy.py ${{ matrix.device }}

--- a/.github/workflows/matchers/clang-tidy.json
+++ b/.github/workflows/matchers/clang-tidy.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "clang-tidy",
+            "pattern": [
+                {
+                    "regexp": "^(.*):(\\d+):(\\d+):\\s+(error):\\s+(.*) \\[([a-z0-9,\\-]+)\\]\\s*$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Compiling and flashing devices normally happens through the ESPHome Dashboard/De
 
 ## Commands
 
-Linting/formatting is enforced via pre-commit (see `.pre-commit-config.yaml`) and run in CI on every push/PR (`.github/workflows/lint.yml`):
+Linting/formatting is enforced via pre-commit (see `.pre-commit-config.yaml`) and run in CI on every push/PR (`.github/workflows/ci.yml`):
 
 ```
 pre-commit run --all-files       # run every hook against the whole repo
@@ -22,6 +22,34 @@ Individual hooks, if you need to invoke a tool directly instead of via pre-commi
 - `flake8` — additional docstring/style checks, scoped to `components/**/*.py` only (`.flake8`).
 - `yamllint` — all YAML files except `.clang-format`/`.clang-tidy` (`.yamllint`: 2-space indent, no line-length limit, `document-start` disabled).
 - `clang-format` — C/C++ files in `components/**` (`.clang-format`).
+
+### clang-tidy
+
+`.clang-tidy` is a copy of upstream ESPHome's, so the C++ in `components/` is held to the same
+checks as ESPHome core. It is **not** a pre-commit hook: clang-tidy needs a device's real
+compiler flags and its generated `esphome/core/defines.h`, which only exist after a compile. CI
+therefore runs it inside the compile matrix, right after each `esphome compile`.
+
+`scripts/clang_tidy.py` is a slimmed-down port of upstream's `script/clang-tidy` (same flag
+surgery — clang can't consume the xtensa/riscv GCC command line, so the flags are rebuilt from
+the build's idedata). It takes the name of a *compiled* device config and checks only the
+components that device built, with that device's defines:
+
+```
+pip install clang-tidy==22.1.8       # the version CI pins
+python scripts/clang_tidy.py pool             # every component in that build
+python scripts/clang_tidy.py pool pump_flow   # only files matching a regex
+python scripts/clang_tidy.py pool --fix       # apply fix-its (runs serially)
+```
+
+A component that runs on both platforms needs a run per platform, same as the compile itself.
+Locally that means compiling a scratch copy of the device first (see "Compiling locally") and
+passing that copy's name.
+
+Review what `--fix` writes before keeping it: it only sees the preprocessor branch the current
+build compiles, so a rename inside `#ifdef USE_SENSOR` lands while the matching `#else`
+definition keeps the old name — which builds fine here and breaks a device without that
+feature. It also re-wraps what it touches in Google style; run clang-format afterwards.
 
 ### ESPHome CLI
 

--- a/components/econet_zone_control/econet_zone_control.cpp
+++ b/components/econet_zone_control/econet_zone_control.cpp
@@ -143,9 +143,10 @@ void EcoNetZoneControl::dump_config() {
   auto dp = [](const char *id) -> const char * { return (id != nullptr && *id) ? id : "(none)"; };
   LOG_CLIMATE("", "EcoNet Zone Control", this);
   ESP_LOGCONFIG(TAG, "  Zones: %zu", this->zones_.size());
-  for (const auto &zone : this->zones_)
+  for (const auto &zone : this->zones_) {
     ESP_LOGCONFIG(TAG, "    src_adr=0x%08X request_mod=%d %s", zone.src_adr, zone.request_mod,
                   zone.is_primary ? "[PRIMARY]" : "");
+  }
   ESP_LOGCONFIG(TAG, "  Mode Datapoint: %s", dp(this->mode_id_));
   ESP_LOGCONFIG(TAG, "  Operating Mode Datapoint: %s", dp(this->operating_mode_id_));
   ESP_LOGCONFIG(TAG, "  Automatic Fan Mode: %u", this->automatic_fan_mode_);
@@ -318,16 +319,19 @@ void EcoNetZoneControl::update_current_action_() {
     new_action = climate::CLIMATE_ACTION_IDLE;
   } else {
     const std::string &state = this->operating_mode_state_;
-    if (state.find("Off") != std::string::npos)
+    // "Off" is matched first and deliberately shares the fallback's body: it must win over a
+    // state string that also contains another keyword, so it cannot be folded into the else.
+    if (state.find("Off") != std::string::npos) {  // NOLINT(bugprone-branch-clone)
       new_action = climate::CLIMATE_ACTION_IDLE;
-    else if (state.find("Heat") != std::string::npos)
+    } else if (state.find("Heat") != std::string::npos) {
       new_action = climate::CLIMATE_ACTION_HEATING;
-    else if (state.find("Cool") != std::string::npos)
+    } else if (state.find("Cool") != std::string::npos) {
       new_action = climate::CLIMATE_ACTION_COOLING;
-    else if (state.find("Fan") != std::string::npos)
+    } else if (state.find("Fan") != std::string::npos) {
       new_action = climate::CLIMATE_ACTION_FAN;
-    else
+    } else {
       new_action = climate::CLIMATE_ACTION_IDLE;
+    }
   }
   if (new_action == this->action)
     return;
@@ -396,6 +400,10 @@ void EcoNetZoneControl::update_zone_fan_mode_() {
         if (max_zone == nullptr || zone.cached_temperature > max_zone->cached_temperature)
           max_zone = &zone;
       }
+      // The schema requires at least two zones, so the scan always assigns both; bail out
+      // rather than dereference null on the empty-zone path.
+      if (min_zone == nullptr || max_zone == nullptr)
+        return;
       if (this->locked_min_zone_ != min_zone || this->locked_max_zone_ != max_zone) {
         ESP_LOGD(TAG, "Fan zone lock set: min=0x%08X max=0x%08X for 15 minutes", min_zone->src_adr, max_zone->src_adr);
       }

--- a/components/pool_controller/auxiliary_pump_switch.cpp
+++ b/components/pool_controller/auxiliary_pump_switch.cpp
@@ -4,15 +4,14 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace pool_controller {
+namespace esphome::pool_controller {
 
 static const char *const TAG = "pool_controller.switch";
 
 void AuxiliaryPumpSwitch::set_primary_pump(PrimaryPumpSwitch *primary_pump) {
   if (primary_pump != nullptr) {
     this->primary_pump_ = primary_pump;
-    primary_pump->add_auxiliary_pump(this);
+    primary_pump->add_auxiliary_pump_(this);
   }
 }
 
@@ -39,21 +38,20 @@ void AuxiliaryPumpSwitch::write_state(bool state) {
     this->arm_new_run_();
   this->output_->set_state(state);
   this->publish_state(state);
-  if (!this->has_current_sensor() && !this->has_flow_sensor()) {
+  if (!this->has_current_sensor_() && !this->has_flow_sensor_()) {
     // No sensors at all — the command is the only evidence available for either job.
     if (state)
       this->turned_on_ms_ = millis_64();
-    this->track_runtime(state);
+    this->track_runtime_(state);
   } else if (!state) {
     // Output commanded off — stop runtime counting immediately regardless of sensor confirmation.
     this->motor_running_ = false;
     this->flow_running_ = false;
-    this->track_runtime(false);
+    this->track_runtime_(false);
   }
   // When a current or flow sensor is configured and state==true: runtime starts in loop() once the
   // sensor confirms the pump is actually running.
   this->update_no_current_();
 }
 
-}  // namespace pool_controller
-}  // namespace esphome
+}  // namespace esphome::pool_controller

--- a/components/pool_controller/pool_controller.cpp
+++ b/components/pool_controller/pool_controller.cpp
@@ -7,8 +7,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace pool_controller {
+namespace esphome::pool_controller {
 
 static const char *const TAG = "pool_controller";
 
@@ -26,9 +25,9 @@ void PoolController::setup() {
 
 void PoolController::restore_pump_states_(const ESPTime &now) {
   if (this->primary_pump_ != nullptr)
-    this->primary_pump_->restore_run_state(now, this->max_resume_age_s_);
+    this->primary_pump_->restore_run_state_(now, this->max_resume_age_s_);
   for (auto *aux : this->auxiliary_pumps_)
-    aux->restore_run_state(now, this->max_resume_age_s_);
+    aux->restore_run_state_(now, this->max_resume_age_s_);
   this->next_state_save_ms_ = millis_64() + this->state_save_interval_ms_;
 }
 
@@ -38,18 +37,17 @@ void PoolController::save_pump_states_if_due_() {
     return;
   this->next_state_save_ms_ = now_ms + this->state_save_interval_ms_;
   if (this->primary_pump_ != nullptr)
-    this->primary_pump_->save_run_state();
+    this->primary_pump_->save_run_state_();
   for (auto *aux : this->auxiliary_pumps_)
-    aux->save_run_state();
+    aux->save_run_state_();
 }
 
-void PoolController::reset_all_pump_runtimes_() {
-  ESP_LOGD(TAG, "Hourly boundary – resetting pump runtime counters (%02d:%02d)", this->last_check_->hour,
-           this->last_check_->minute);
+void PoolController::reset_all_pump_runtimes_(const ESPTime &now) {
+  ESP_LOGD(TAG, "Hourly boundary – resetting pump runtime counters (%02d:%02d)", now.hour, now.minute);
   if (this->primary_pump_ != nullptr)
-    this->primary_pump_->reset_runtime();
+    this->primary_pump_->reset_runtime_();
   for (auto *aux : this->auxiliary_pumps_)
-    aux->reset_runtime();
+    aux->reset_runtime_();
 }
 
 void PoolController::tick_all_pump_schedules_(const ESPTime &now) {
@@ -115,7 +113,7 @@ void PoolController::tick_pump_schedule_(PumpSwitch *pump, const ESPTime &now) {
     }
     // Target on-time for this 1-hour window:
     //   minutes_per_hour converted to seconds  =  minutes_per_hour * 60
-    const ScheduleRuntime *rt = pump->find_active_runtime(slot_start, now.day_of_week);
+    const ScheduleRuntime *rt = pump->find_active_runtime_(slot_start, now.day_of_week);
     if (rt != nullptr && rt->minutes_per_hour > 0)
       target_seconds = static_cast<uint32_t>(rt->minutes_per_hour) * 60;
   }
@@ -159,9 +157,10 @@ void PoolController::request_primary_turn_off_() {
     this->pool_heater_->request_heater_off();
 
   // Turn off all auxiliary pumps immediately.
-  for (auto *aux : this->auxiliary_pumps_)
+  for (auto *aux : this->auxiliary_pumps_) {
     if (aux->state)
       aux->turn_off();
+  }
 
   // Queue the primary pump turn-off after sequence_delay_ms_ (if not already pending).
   if (this->primary_pump_ != nullptr && this->primary_pump_->state && !this->primary_turn_off_pending_) {
@@ -186,7 +185,7 @@ bool PoolController::any_auxiliary_needs_primary_(uint16_t slot_start, uint8_t d
       continue;
     if (aux->is_disabled())
       continue;
-    const ScheduleRuntime *rt = aux->find_active_runtime(slot_start, day_of_week);
+    const ScheduleRuntime *rt = aux->find_active_runtime_(slot_start, day_of_week);
     if (rt == nullptr || rt->minutes_per_hour == 0)
       continue;
     const uint32_t target = static_cast<uint32_t>(rt->minutes_per_hour) * 60;
@@ -219,15 +218,18 @@ void PoolController::loop() {
   static constexpr int MAX_TIMESTAMP_DRIFT = 900;  // seconds
 
   if (this->last_check_.has_value()) {
-    if (*this->last_check_ > now && this->last_check_->timestamp - now.timestamp > MAX_TIMESTAMP_DRIFT) {
+    // Bind the contained value once, under the has_value() guard: every use below is then
+    // plainly checked, including the ones after a call that clang-tidy cannot see into.
+    ESPTime &last_check = *this->last_check_;
+    if (last_check > now && last_check.timestamp - now.timestamp > MAX_TIMESTAMP_DRIFT) {
       // Clock jumped backwards (e.g. NTP correction) — reset tracking.
       ESP_LOGW(TAG, "Time has jumped back — resetting runtime counter tracking");
       this->last_check_ = now;
       return;
-    } else if (*this->last_check_ >= now) {
+    } else if (last_check >= now) {
       // Already handled this second.
       return;
-    } else if (now > *this->last_check_ && now.timestamp - this->last_check_->timestamp > MAX_TIMESTAMP_DRIFT) {
+    } else if (now > last_check && now.timestamp - last_check.timestamp > MAX_TIMESTAMP_DRIFT) {
       // Clock jumped forward — skip ahead without firing missed resets.
       ESP_LOGW(TAG, "Time has jumped forward — skipping missed runtime resets");
       this->last_check_ = now;
@@ -236,19 +238,19 @@ void PoolController::loop() {
 
     // Walk second-by-second so no :00 boundary is ever missed.
     while (true) {
-      this->last_check_->increment_second();
-      if (*this->last_check_ >= now)
+      last_check.increment_second();
+      if (last_check >= now)
         break;
-      if (this->last_check_->second == 0 && this->last_check_->minute == 0)
-        this->reset_all_pump_runtimes_();
-      this->tick_all_pump_schedules_(*this->last_check_);
+      if (last_check.second == 0 && last_check.minute == 0)
+        this->reset_all_pump_runtimes_(last_check);
+      this->tick_all_pump_schedules_(last_check);
     }
   }
 
   this->last_check_ = now;
 
   if (now.second == 0 && now.minute == 0)
-    this->reset_all_pump_runtimes_();
+    this->reset_all_pump_runtimes_(now);
   this->tick_all_pump_schedules_(now);
 
   // Snapshot last, so a save landing on an hour boundary records the post-reset counters
@@ -256,5 +258,4 @@ void PoolController::loop() {
   this->save_pump_states_if_due_();
 }
 
-}  // namespace pool_controller
-}  // namespace esphome
+}  // namespace esphome::pool_controller

--- a/components/pool_controller/pool_controller.h
+++ b/components/pool_controller/pool_controller.h
@@ -11,8 +11,7 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/time/real_time_clock.h"
 
-namespace esphome {
-namespace pool_controller {
+namespace esphome::pool_controller {
 
 class PoolHeater;  // forward declaration — full type in pool_heater.h
 
@@ -64,7 +63,9 @@ class PoolController : public Component {
   /// Writes every pump's state if the snapshot interval has elapsed.
   void save_pump_states_if_due_();
 
-  void reset_all_pump_runtimes_();
+  /// `now` is the boundary being handled -- the walked time while catching up, not
+  /// necessarily the current clock.
+  void reset_all_pump_runtimes_(const ESPTime &now);
   void tick_all_pump_schedules_(const ESPTime &now);
   void tick_pump_schedule_(PumpSwitch *pump, const ESPTime &now);
 
@@ -82,5 +83,4 @@ class PoolController : public Component {
   bool primary_is_ready_for_aux_() const;
 };
 
-}  // namespace pool_controller
-}  // namespace esphome
+}  // namespace esphome::pool_controller

--- a/components/pool_controller/pool_heater.cpp
+++ b/components/pool_controller/pool_heater.cpp
@@ -7,8 +7,7 @@
 #include <cinttypes>
 #include <cmath>
 
-namespace esphome {
-namespace pool_controller {
+namespace esphome::pool_controller {
 
 static const char *const TAG = "pool_controller.heater";
 
@@ -190,5 +189,4 @@ void PoolHeater::apply_control_() {
   }
 }
 
-}  // namespace pool_controller
-}  // namespace esphome
+}  // namespace esphome::pool_controller

--- a/components/pool_controller/pool_heater.h
+++ b/components/pool_controller/pool_heater.h
@@ -5,8 +5,7 @@
 #include "esphome/components/output/binary_output.h"
 #include "esphome/components/water_heater/water_heater.h"
 
-namespace esphome {
-namespace pool_controller {
+namespace esphome::pool_controller {
 
 // Forward declaration — full type visible via pump_switch.h in pool_heater.cpp.
 class PrimaryPumpSwitch;
@@ -73,5 +72,4 @@ class PoolHeater : public water_heater::WaterHeater, public Component {
   /// so it doubles as the "have I ever received a valid reading?" guard.
 };
 
-}  // namespace pool_controller
-}  // namespace esphome
+}  // namespace esphome::pool_controller

--- a/components/pool_controller/primary_pump_switch.cpp
+++ b/components/pool_controller/primary_pump_switch.cpp
@@ -5,12 +5,11 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace pool_controller {
+namespace esphome::pool_controller {
 
 static const char *const TAG = "pool_controller.switch";
 
-void PrimaryPumpSwitch::add_auxiliary_pump(AuxiliaryPumpSwitch *aux_switch) {
+void PrimaryPumpSwitch::add_auxiliary_pump_(AuxiliaryPumpSwitch *aux_switch) {
   if (aux_switch != nullptr) {
     this->auxiliary_pumps_.push_back(aux_switch);
   }
@@ -45,7 +44,7 @@ void PrimaryPumpSwitch::write_state(bool state) {
         this->publish_state(false);
         this->motor_running_ = false;
         this->flow_running_ = false;
-        this->track_runtime(false);
+        this->track_runtime_(false);
         this->update_no_current_();
       });
       return;
@@ -56,21 +55,20 @@ void PrimaryPumpSwitch::write_state(bool state) {
     this->arm_new_run_();
   this->output_->set_state(state);
   this->publish_state(state);
-  if (!this->has_current_sensor() && !this->has_flow_sensor()) {
+  if (!this->has_current_sensor_() && !this->has_flow_sensor_()) {
     // No sensors at all — the command is the only evidence available for either job.
     if (state)
       this->turned_on_ms_ = millis_64();
-    this->track_runtime(state);
+    this->track_runtime_(state);
   } else if (!state) {
     // Output commanded off — stop runtime counting immediately regardless of sensor confirmation.
     this->motor_running_ = false;
     this->flow_running_ = false;
-    this->track_runtime(false);
+    this->track_runtime_(false);
   }
   // When a current or flow sensor is configured and state==true: runtime starts in loop() once the
   // sensor confirms the pump is actually running.
   this->update_no_current_();
 }
 
-}  // namespace pool_controller
-}  // namespace esphome
+}  // namespace esphome::pool_controller

--- a/components/pool_controller/pump_anomaly.cpp
+++ b/components/pool_controller/pump_anomaly.cpp
@@ -6,8 +6,7 @@
 #include <cmath>
 #include <cinttypes>
 
-namespace esphome {
-namespace pool_controller {
+namespace esphome::pool_controller {
 
 static const char *const TAG = "pool_controller.switch";
 
@@ -57,7 +56,7 @@ static constexpr float EMA_DRIFT_ALPHA = 0.001f;
 
 void PumpSwitch::tick_anomaly_() {
   // A baseline reset arms capture but doesn't start it: wait for the next turn-on so the new
-  // baseline is built from a whole run, startup window included. track_runtime() clears this.
+  // baseline is built from a whole run, startup window included. track_runtime_() clears this.
   if (this->awaiting_fresh_start_)
     return;
 
@@ -81,7 +80,7 @@ void PumpSwitch::tick_anomaly_() {
     // never required — a pump takes a moment to prime, so the whole window is allowed for it.
     if (current > this->startup_peak_current_)
       this->startup_peak_current_ = current;
-    if (this->has_flow_sensor() && this->flow_sensor_->state)
+    if (this->has_flow_sensor_() && this->flow_sensor_->state)
       this->run_flow_confirmed_ = true;
     return;
   }
@@ -272,5 +271,4 @@ void PumpAnomalyReasonTextSensor::setup() {
 
 #endif  // USE_SENSOR
 
-}  // namespace pool_controller
-}  // namespace esphome
+}  // namespace esphome::pool_controller

--- a/components/pool_controller/pump_anomaly.h
+++ b/components/pool_controller/pump_anomaly.h
@@ -9,8 +9,7 @@
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
-namespace esphome {
-namespace pool_controller {
+namespace esphome::pool_controller {
 
 class PumpAnomalySwitch : public switch_::Switch, public Component {
  public:
@@ -64,5 +63,4 @@ class PumpAnomalyTrigger : public Trigger<std::string> {
   explicit PumpAnomalyTrigger(PumpSwitch *parent) { parent->set_anomaly_trigger(this); }
 };
 
-}  // namespace pool_controller
-}  // namespace esphome
+}  // namespace esphome::pool_controller

--- a/components/pool_controller/pump_current.cpp
+++ b/components/pool_controller/pump_current.cpp
@@ -6,8 +6,7 @@
 #include <cinttypes>
 #include <cmath>
 
-namespace esphome {
-namespace pool_controller {
+namespace esphome::pool_controller {
 
 static const char *const TAG = "pool_controller.switch";
 
@@ -15,7 +14,7 @@ void PumpSwitch::update_no_current_() {
   // Suppressed while the reading is stale: "commanded on but no current" is a claim about the
   // pump, and a sensor that stopped publishing supports no such claim. The stale sensor carries
   // the alarm instead, so the two faults stay distinguishable in the UI and in history.
-  const bool fault = this->has_current_sensor() && this->state && !this->motor_running_ && !this->current_stale_;
+  const bool fault = this->has_current_sensor_() && this->state && !this->motor_running_ && !this->current_stale_;
   if (fault == this->no_current_detected_)
     return;
   this->no_current_detected_ = fault;
@@ -91,14 +90,14 @@ void PumpSwitch::update_current_sensor_(uint64_t now) {
         if (motor_running && this->turned_on_ms_ == 0)
           this->turned_on_ms_ = millis_64();
         // Runtime follows flow whenever a flow sensor is configured; see update_flow_based_runtime_().
-        if (!this->has_flow_sensor())
-          this->track_runtime(motor_running);
+        if (!this->has_flow_sensor_())
+          this->track_runtime_(motor_running);
         this->update_no_current_();
       }
     }
 
     // Anomaly detection: gate on motor_running_ (current-confirmed), not state (commanded).
-    // track_runtime() above only refreshes turned_on_ms_ on a motor_running_ transition, so
+    // track_runtime_() above only refreshes turned_on_ms_ on a motor_running_ transition, so
     // ticking on state alone can run tick_anomaly_() before turned_on_ms_ reflects this run,
     // leaving run_ms computed against the previous run's turn-on time.
     if (this->enable_anomaly_detection_ && this->motor_running_)
@@ -117,5 +116,4 @@ void PumpCurrentStaleBinarySensor::setup() {
 }
 #endif  // USE_SENSOR
 
-}  // namespace pool_controller
-}  // namespace esphome
+}  // namespace esphome::pool_controller

--- a/components/pool_controller/pump_current.h
+++ b/components/pool_controller/pump_current.h
@@ -5,8 +5,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
-namespace esphome {
-namespace pool_controller {
+namespace esphome::pool_controller {
 
 /// Problem sensor: true while the pump is commanded on but no current is detected.
 class PumpNoCurrentBinarySensor : public binary_sensor::BinarySensor, public Component {
@@ -34,5 +33,4 @@ class PumpCurrentStaleBinarySensor : public binary_sensor::BinarySensor, public 
   PumpSwitch *pump_{nullptr};
 };
 
-}  // namespace pool_controller
-}  // namespace esphome
+}  // namespace esphome::pool_controller

--- a/components/pool_controller/pump_flow.cpp
+++ b/components/pool_controller/pump_flow.cpp
@@ -5,8 +5,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace pool_controller {
+namespace esphome::pool_controller {
 
 static const char *const TAG = "pool_controller.switch";
 
@@ -41,9 +40,9 @@ void PumpSwitch::update_flow_based_runtime_(uint64_t now) {
   // With no current sensor, flow is also the only evidence the motor is turning, so it has to
   // anchor the turn-on timestamp as well. When current is available it does that job instead,
   // because it sees the motor a second or more earlier.
-  if (!this->has_current_sensor() && flow_running && this->turned_on_ms_ == 0)
+  if (!this->has_current_sensor_() && flow_running && this->turned_on_ms_ == 0)
     this->turned_on_ms_ = millis_64();
-  this->track_runtime(flow_running);
+  this->track_runtime_(flow_running);
 }
 
 void PumpSwitch::update_flow_watchdogs_(uint64_t now) {
@@ -51,7 +50,7 @@ void PumpSwitch::update_flow_watchdogs_(uint64_t now) {
   // Only shuts the pump down when a current sensor confirms the motor is actually running.
   // Without that confirmation, "commanded on but no flow" is indistinguishable from a manual
   // override switch physically holding the pump off, so no-flow alone must not trigger a shutdown.
-  if (this->has_current_sensor()) {
+  if (this->has_current_sensor_()) {
     const bool should_have_flow = this->motor_running_;
 
     if (should_have_flow && !this->flow_sensor_->state) {
@@ -109,5 +108,4 @@ void PumpFlowLossBinarySensor::setup() {
 }
 #endif  // USE_SENSOR
 
-}  // namespace pool_controller
-}  // namespace esphome
+}  // namespace esphome::pool_controller

--- a/components/pool_controller/pump_flow.h
+++ b/components/pool_controller/pump_flow.h
@@ -5,8 +5,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
-namespace esphome {
-namespace pool_controller {
+namespace esphome::pool_controller {
 
 /// Problem sensor: latches true when the pump is shut down due to lost flow; only clears once
 /// the pump is on, current confirms the motor is running, and flow is detected again.
@@ -30,5 +29,4 @@ class PumpUnexpectedFlowBinarySensor : public binary_sensor::BinarySensor, publi
   PumpSwitch *pump_{nullptr};
 };
 
-}  // namespace pool_controller
-}  // namespace esphome
+}  // namespace esphome::pool_controller

--- a/components/pool_controller/pump_switch.cpp
+++ b/components/pool_controller/pump_switch.cpp
@@ -5,8 +5,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace pool_controller {
+namespace esphome::pool_controller {
 
 static const char *const TAG = "pool_controller.switch";
 
@@ -31,7 +30,7 @@ void PumpSwitch::setup() {
     this->saved_run_state_ = PumpRunState();
     // The snapshot is deliberately not applied here. Deciding whether it is still worth trusting
     // needs a valid wall clock, which isn't available this early in boot, so PoolController calls
-    // restore_run_state() once time is valid. Until then the pump behaves as if starting cold.
+    // restore_run_state_() once time is valid. Until then the pump behaves as if starting cold.
 
 #ifdef USE_SENSOR
   if (this->current_sensor_ != nullptr) {
@@ -55,22 +54,22 @@ void PumpSwitch::setup() {
 
   this->set_anomaly_detected_(false);
   this->turn_off();
-  // Hold the full minimum off-time from boot. restore_run_state() relaxes this if the saved
+  // Hold the full minimum off-time from boot. restore_run_state_() relaxes this if the saved
   // snapshot shows the pump was mid-run, or credits off-time already served.
   this->can_turn_on_at_ms_ = millis_64() + MIN_OFF_TIME_MS;
 }
 
-void PumpSwitch::reset_runtime() {
+void PumpSwitch::reset_runtime_() {
   if (this->runtime_start_ms_ != 0) {
     // Pump is still running; restart the window so elapsed time in the new period is accurate.
     this->runtime_start_ms_ = millis_64();
   }
   this->runtime_seconds_ = 0;
-  this->save_run_state();
+  this->save_run_state_();
   ESP_LOGD(TAG, "Runtime counter reset");
 }
 
-void PumpSwitch::save_run_state() {
+void PumpSwitch::save_run_state_() {
   if (this->rtc_ == nullptr)
     return;
   const ESPTime now = this->rtc_->now();
@@ -106,7 +105,7 @@ void PumpSwitch::save_run_state() {
   global_preferences->sync();
 }
 
-void PumpSwitch::restore_run_state(const ESPTime &now, uint32_t max_age_s) {
+void PumpSwitch::restore_run_state_(const ESPTime &now, uint32_t max_age_s) {
   const PumpRunState &state = this->saved_run_state_;
   if (state.saved_utc == 0) {
     ESP_LOGD(TAG, "'%s' no saved state to resume from", this->get_name().c_str());
@@ -165,13 +164,13 @@ void PumpSwitch::arm_new_run_() {
   this->awaiting_fresh_start_ = false;
 }
 
-void PumpSwitch::track_runtime(bool new_state) {
+void PumpSwitch::track_runtime_(bool new_state) {
   if (new_state && this->runtime_start_ms_ == 0) {
     this->runtime_start_ms_ = millis_64();
     this->last_off_utc_ = 0;
     // Snapshot the start immediately: a restart moments from now needs to know the pump was
     // mid-run, which is what lets it resume without waiting out the minimum off-time.
-    this->save_run_state();
+    this->save_run_state_();
   } else if (!new_state && this->runtime_start_ms_ != 0) {
     this->runtime_seconds_ += (millis_64() - this->runtime_start_ms_) / 1000;
     this->runtime_start_ms_ = 0;
@@ -181,7 +180,7 @@ void PumpSwitch::track_runtime(bool new_state) {
       if (off_at.is_valid())
         this->last_off_utc_ = static_cast<uint32_t>(off_at.timestamp);
     }
-    this->save_run_state();
+    this->save_run_state_();
     // Deliberately NOT clearing anomaly_detected_ here: turning off is not evidence the
     // problem is resolved. Once tripped, the flag stays latched across the off period and
     // into subsequent runs until tick_anomaly_()'s in-spec hysteresis check (current back
@@ -197,7 +196,7 @@ void PumpSwitch::set_anomaly_detected_(bool detected) {
     this->anomaly_status_sensor_->publish_state(detected);
 }
 
-const ScheduleRuntime *PumpSwitch::find_active_runtime(uint16_t slot_start_minute, uint8_t day_of_week) const {
+const ScheduleRuntime *PumpSwitch::find_active_runtime_(uint16_t slot_start_minute, uint8_t day_of_week) const {
   // active_schedule_idx_ 0 = Off, 1..N = user schedules (1-based), N+1 = builtin last.
   if (this->active_schedule_idx_ == 0 || this->active_schedule_idx_ > this->schedules_.size())
     return nullptr;
@@ -229,5 +228,4 @@ void PumpSwitch::loop() {
   }
 }
 
-}  // namespace pool_controller
-}  // namespace esphome
+}  // namespace esphome::pool_controller

--- a/components/pool_controller/pump_switch.h
+++ b/components/pool_controller/pump_switch.h
@@ -14,8 +14,7 @@
 #include "esphome/components/sensor/sensor.h"
 #endif
 
-namespace esphome {
-namespace pool_controller {
+namespace esphome::pool_controller {
 
 /// A single time window within a schedule.
 struct ScheduleRuntime {
@@ -177,19 +176,19 @@ class PumpSwitch : public switch_::Switch, public Component {
   friend class PoolController;
 
   /// Resets accumulated runtime to zero. Called by PoolController at :00.
-  void reset_runtime();
+  void reset_runtime_();
 
   /// Accumulates runtime. Driven by the best available evidence that the pump is doing work:
   /// flow when a flow sensor is configured, otherwise current, otherwise the output command.
   /// Flow wins because moving water is what the schedule is actually buying, and because it
   /// stays valid through a current-sensor outage — see [Stale Current Readings] in the README.
-  void track_runtime(bool new_state);
+  void track_runtime_(bool new_state);
 
   /// Marks the start of a new run, at the moment the output is commanded on. Clears the per-run
   /// anomaly state and sets turned_on_ms_ to 0, meaning "commanded on, not yet confirmed
   /// running"; whichever sensor first confirms the motor stamps the real timestamp.
   ///
-  /// Separate from track_runtime() because the two answer different questions. Runtime asks how
+  /// Separate from track_runtime_() because the two answer different questions. Runtime asks how
   /// long the pump did useful work, which flow answers best. The anomaly startup window asks
   /// when the motor was energised, which only current answers — flow lags the motor by a second
   /// or more, easily long enough to miss the inrush peak entirely.
@@ -199,14 +198,14 @@ class PumpSwitch : public switch_::Switch, public Component {
   /// Persists the current operating state with a wall-clock timestamp. No-op until the clock is
   /// valid: an untimestamped snapshot cannot be aged on restore, which makes it worse than none.
   /// Called on every start/stop and periodically by PoolController.
-  void save_run_state();
+  void save_run_state_();
 
   /// Applies the snapshot loaded in setup(), if it is still worth trusting. Called once by
   /// PoolController as soon as the clock is valid and before the first schedule tick, so a
   /// resumed runtime is in place before anything decides whether the pump should be running.
   /// `max_age_s` is the outage length beyond which the snapshot is discarded and the pump
   /// starts cold.
-  void restore_run_state(const ESPTime &now, uint32_t max_age_s);
+  void restore_run_state_(const ESPTime &now, uint32_t max_age_s);
 
   /// Re-evaluates the no-current problem sensor from current `state`/`motor_running_`.
   void update_no_current_();
@@ -218,7 +217,7 @@ class PumpSwitch : public switch_::Switch, public Component {
   /// Returns the ScheduleRuntime from the active user-defined schedule that covers
   /// [slot_start_minute, slot_start_minute+60), for the given day_of_week (1=Sun..7=Sat).
   /// Returns nullptr if no matching runtime exists or the active schedule is not a user schedule.
-  const ScheduleRuntime *find_active_runtime(uint16_t slot_start_minute, uint8_t day_of_week) const;
+  const ScheduleRuntime *find_active_runtime_(uint16_t slot_start_minute, uint8_t day_of_week) const;
 
   output::BinaryOutput *output_ = nullptr;
   std::vector<Schedule> schedules_;
@@ -234,7 +233,7 @@ class PumpSwitch : public switch_::Switch, public Component {
   binary_sensor::BinarySensor *disable_pumps_sensor_{
       nullptr};                         ///< Optional sensor that turns off pumps and blocks turn-ons when active.
   ESPPreferenceObject run_state_pref_;  ///< Persists PumpRunState across reboots.
-  PumpRunState saved_run_state_{};      ///< Snapshot read in setup(), applied later by restore_run_state().
+  PumpRunState saved_run_state_{};      ///< Snapshot read in setup(), applied later by restore_run_state_().
 
   // ── Anomaly detection state ────────────────────────────────────────────────
   bool enable_anomaly_detection_{false};
@@ -290,9 +289,9 @@ class PumpSwitch : public switch_::Switch, public Component {
 
   /// Returns true when a current sensor is configured for this pump.
 #ifdef USE_SENSOR
-  bool has_current_sensor() const { return this->current_sensor_ != nullptr; }
+  bool has_current_sensor_() const { return this->current_sensor_ != nullptr; }
 #else
-  bool has_current_sensor() const { return false; }
+  bool has_current_sensor_() const { return false; }
 #endif
 
   // ── Flow sensor state ──────────────────────────────────────────────────────
@@ -309,14 +308,14 @@ class PumpSwitch : public switch_::Switch, public Component {
   uint64_t unexpected_flow_check_start_ms_{0};  ///< millis_64() when unexpected flow first detected; 0 if clear.
 
   /// Returns true when a flow sensor is configured for this pump.
-  bool has_flow_sensor() const { return this->flow_sensor_ != nullptr; }
+  bool has_flow_sensor_() const { return this->flow_sensor_ != nullptr; }
 
   /// Whether anomaly statistics may be captured at this instant.
   /// With a flow sensor, current draw alone isn't enough — a pump that is spinning but moving
   /// no water draws an atypical current that must not be folded into the baseline, so capture
   /// requires water actually moving. Without one, current is the only evidence available and
   /// the caller has already confirmed the motor is drawing it (motor_running_).
-  bool stats_capture_allowed_() const { return !this->has_flow_sensor() || this->flow_sensor_->state; }
+  bool stats_capture_allowed_() const { return !this->has_flow_sensor_() || this->flow_sensor_->state; }
 
   /// Whether this run's inrush peak is worth folding into the startup reference. A gap in the
   /// current readings means the window was only partly observed, so the "peak" is whatever
@@ -324,7 +323,7 @@ class PumpSwitch : public switch_::Switch, public Component {
   /// got water moving counts either; a motor that spun up against a closed valve or lost prime
   /// produces a peak that would poison the reference.
   bool startup_capture_valid_() const {
-    return !this->run_current_gap_ && (!this->has_flow_sensor() || this->run_flow_confirmed_);
+    return !this->run_current_gap_ && (!this->has_flow_sensor_() || this->run_flow_confirmed_);
   }
 
 #ifdef USE_SENSOR
@@ -357,7 +356,7 @@ class PrimaryPumpSwitch : public PumpSwitch {
 
  protected:
   friend class AuxiliaryPumpSwitch;
-  void add_auxiliary_pump(AuxiliaryPumpSwitch *aux_switch);
+  void add_auxiliary_pump_(AuxiliaryPumpSwitch *aux_switch);
   void write_state(bool state) override;
 
   std::vector<AuxiliaryPumpSwitch *> auxiliary_pumps_;
@@ -374,5 +373,4 @@ class AuxiliaryPumpSwitch : public PumpSwitch {
   PrimaryPumpSwitch *primary_pump_ = nullptr;
 };
 
-}  // namespace pool_controller
-}  // namespace esphome
+}  // namespace esphome::pool_controller

--- a/components/pool_controller/schedule_select.cpp
+++ b/components/pool_controller/schedule_select.cpp
@@ -2,8 +2,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pool_controller {
+namespace esphome::pool_controller {
 
 static const char *const TAG = "pool_controller.select";
 
@@ -32,5 +31,4 @@ void ScheduleSelect::control(size_t index) {
   this->publish_state(index);
 }
 
-}  // namespace pool_controller
-}  // namespace esphome
+}  // namespace esphome::pool_controller

--- a/components/pool_controller/schedule_select.h
+++ b/components/pool_controller/schedule_select.h
@@ -6,8 +6,7 @@
 #include "esphome/core/preferences.h"
 #include "esphome/components/select/select.h"
 
-namespace esphome {
-namespace pool_controller {
+namespace esphome::pool_controller {
 
 /// A Select entity whose options are the named schedules of a PumpSwitch.
 /// Selecting an option sets the pump's active schedule index.
@@ -26,5 +25,4 @@ class ScheduleSelect : public select::Select, public Component {
   ESPPreferenceObject pref_;
 };
 
-}  // namespace pool_controller
-}  // namespace esphome
+}  // namespace esphome::pool_controller

--- a/scripts/clang_tidy.py
+++ b/scripts/clang_tidy.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Run clang-tidy over this repo's custom C++ components.
+
+This is a slimmed-down port of upstream ESPHome's `script/clang-tidy`, and it uses the
+same `.clang-tidy` check list, so the components here are held to the same C++ rules as
+ESPHome core. Two things make it more than a plain `clang-tidy components/**/*.cpp`:
+
+* clang cannot consume the xtensa/riscv GCC command line the real build uses, so the
+  compiler flags are rebuilt from the build's *idedata* (compiler flags, defines and
+  include dirs) with the GCC-only flags dropped and the Arduino/newlib headers that use
+  GNU extensions macro-replaced. That flag surgery is copied from upstream.
+* the components only compile against a *device's* generated `esphome/core/defines.h`
+  (USE_ESP32, USE_ESP8266, which core components are enabled, ...), so the idedata has
+  to come from a real build.
+
+Upstream keeps dedicated "tidy" PlatformIO environments to produce that idedata. This
+repo has no platformio.ini of its own, so it comes from an actual device build instead
+-- which CI already does:
+
+    esphome compile devices/pool.yaml
+    python scripts/clang_tidy.py pool
+
+Only the components that device built are checked, with that device's real defines, so
+a component that builds for both platforms gets analyzed once per platform (an esp32
+build says nothing about the esp8266 one, same as for the compile itself).
+"""
+
+import argparse
+import concurrent.futures
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COMPONENTS_DIR = REPO_ROOT / "components"
+DEVICES_DIR = REPO_ROOT / "devices"
+
+IN_ACTIONS = os.environ.get("GITHUB_ACTIONS") == "true"
+
+# GCC-only flags the ESP-IDF/Arduino builds emit that clang rejects outright.
+OMIT_FLAGS = (
+    "-free",
+    "-fipa-pta",
+    "-fstrict-volatile-bitfields",
+    "-mlongcalls",
+    "-mtext-section-literals",
+    "-mdisable-hardware-atomics",
+    "-mfix-esp32-psram-cache-issue",
+    "-mfix-esp32-psram-cache-strategy=memw",
+    "-fno-tree-switch-conversion",
+    "-freorder-blocks",
+    "-fno-jump-tables",
+    "-fno-shrink-wrap",
+    "-mno-target-align",
+)
+
+
+def toolchain_triplet(cxx_path):
+    """Target triplet from the compiler filename, e.g. `xtensa-esp32s3-elf`."""
+    name = Path(cxx_path).name
+    if name.lower().endswith(".exe"):
+        name = name[: -len(".exe")]
+    return re.sub(r"-(g|c|clang)\+\+$", "", name)
+
+
+def path_regex(path):
+    """Regex matching `path` with either separator.
+
+    clang-tidy matches --header-filter against the path as the platform spells it, so a
+    filter built with one separator silently matches nothing on the other -- and a
+    header filter that matches nothing hides every finding in our headers.
+    """
+    return "[\\\\/]".join(
+        re.escape(part) for part in str(path).replace("\\", "/").split("/")
+    )
+
+
+def clang_options(idedata, src_dir):
+    """Translate a build's idedata into a clang command line.
+
+    Ported from upstream `script/clang-tidy`; the comments explaining *why* each hack is
+    needed are kept, since they encode a lot of hard-won detail about these toolchains.
+    """
+    cmd = []
+    triplet = toolchain_triplet(idedata["cxx_path"])
+
+    if triplet.startswith("xtensa-"):
+        # clang has an Xtensa frontend, but only a generic core -- the esp32 IDF
+        # toolchain headers (xtruntime, xtensa/config) need the GCC core config
+        # (XCHAL_*) it doesn't ship, so we still compile in 32-bit x86 mode and
+        # just pretend to be Xtensa. Undefine the host x86 arch macros -m32 sets,
+        # and define the xtensa endianness macro newlib's machine/ieeefp.h then
+        # needs in their place.
+        cmd += ["-m32", "-U__i386__", "-U__x86_64__"]
+        cmd += ["-D__XTENSA__", "-D__XTENSA_EL__", "-D_LIBC"]
+    else:
+        # RISC-V has a real clang backend, so compile for the actual triplet.
+        cmd.append(f"--target={triplet}")
+
+    # The build passes flags (e.g. -fno-plt) that clang accepts for some targets but
+    # not others, plus a redundant -nostdinc++ below; an unused one is not a code
+    # quality signal, and .clang-tidy makes every warning an error.
+    cmd.append("-Qunused-arguments")
+
+    # The toolchain headers need clang to claim GCC compatibility: newlib's _ansi.h and
+    # sys/cdefs.h key their __GNUC_PREREQ ladders off __GNUC__, and with it undefined
+    # they fall back to `throw()` exception specifications (removed in C++17, so a hard
+    # error), a locally redefined __alignof, and no __GCC_ATOMIC_* macros for
+    # libstdc++'s atomic_base.h -- a dozen errors in headers the real build compiles
+    # fine. On Linux, where CI runs, clang defines __GNUC__ 4.2.1 by default and this
+    # flag changes nothing; on Windows it defaults to an MSVC target that defines none
+    # of it, so state the same version explicitly rather than diverge per host.
+    cmd.append("-fgnuc-version=4.2.1")
+
+    cmd += [
+        # disable built-in include directories from the host
+        "-nostdinc",
+        "-nostdinc++",
+        # allow to condition code on the presence of clang-tidy
+        "-DCLANG_TIDY",
+        # (esp-idf) Fix __once_callable in some libstdc++ headers
+        "-D_GLIBCXX_HAVE_TLS",
+        # suppress warning about attribute cannot be applied to type
+        # https://github.com/esp8266/Arduino/pull/8258
+        "-Ddeprecated(x)=",
+        # replace pgmspace.h, as it uses GNU extensions clang doesn't support
+        # https://github.com/earlephilhower/newlib-xtensa/pull/18
+        "-D_PGMSPACE_H_",
+        "-Dpgm_read_byte(s)=(*(const uint8_t *)(s))",
+        "-Dpgm_read_byte_near(s)=(*(const uint8_t *)(s))",
+        "-Dpgm_read_word(s)=(*(const uint16_t *)(s))",
+        "-Dpgm_read_dword(s)=(*(const uint32_t *)(s))",
+        "-Dpgm_read_ptr(s)=(*(const void *const *)(s))",
+        "-DPROGMEM=",
+        "-DPGM_P=const char *",
+        "-DPSTR(s)=(s)",
+        # this next one is also needed with upstream pgmspace.h
+        # suppress warning about identifier naming in expansion of this macro
+        "-DPSTRN(s, n)=(s)",
+    ]
+
+    # Espressif's RISC-V GCC -march adds vendor extensions (xesploop, xespv) clang
+    # doesn't know; clang rejects the whole arch string otherwise.
+    def strip_esp_march(flag):
+        if flag.startswith("-march=") and triplet.startswith("riscv"):
+            return re.sub(r"_xesp\w+", "", flag)
+        return flag
+
+    # A single idedata flag can carry several newline-separated flags: ESP-IDF puts them
+    # in a GCC response file, and on Windows ESPHome tokenizes that with the Win32 argv
+    # parser, which doesn't treat a newline as a separator. Flatten first, or the
+    # GCC-only flags ride into clang inside a token that never matches OMIT_FLAGS.
+    build_flags = [
+        line for flag in idedata["cxx_flags"] for line in flag.splitlines() if line
+    ]
+
+    # Copy the build's compiler flags, dropping the ones clang doesn't understand and
+    # -Werror* (clang-tidy enforces .clang-tidy's WarningsAsErrors, and a build -Werror
+    # would bypass the -clang-diagnostic-* suppressions there).
+    cmd += [
+        strip_esp_march(flag)
+        for flag in build_flags
+        if flag not in OMIT_FLAGS
+        and not flag.startswith("-Werror")
+        and not flag.startswith("-mtune=esp")
+    ]
+    if not any(flag.startswith("-std=") for flag in cmd):
+        cmd.append("-std=gnu++20")
+
+    # Analyze with logging fully enabled, as upstream's tidy environments do. These
+    # devices build with `log_level: none`, which preprocesses every ESP_LOG* call
+    # away -- that hides the code inside them from analysis entirely, and makes
+    # variables that exist only to be logged look unused.
+    defines = [
+        define
+        for define in idedata["defines"]
+        if not define.startswith("ESPHOME_LOG_LEVEL=")
+    ]
+    defines.append("ESPHOME_LOG_LEVEL=ESPHOME_LOG_LEVEL_VERY_VERBOSE")
+    cmd += [f"-D{define}" for define in defines]
+
+    # Toolchain include directories, as -isystem so their own warnings are suppressed.
+    # idedata lists the include dirs of every toolchain for the platform; only use the
+    # one actually in use.
+    # normpath both sides of the prefix test: idedata keeps the separators the build
+    # used, which on Windows are not the ones os.path builds the toolchain dir with.
+    toolchain_dir = os.path.normpath(f"{idedata['cxx_path']}/../../")
+    for directory in idedata["includes"]["toolchain"]:
+        if (
+            os.path.normpath(directory).startswith(toolchain_dir)
+            and "picolibc" not in directory
+        ):
+            cmd += ["-isystem", directory]
+
+    # Library/framework include directories, likewise -isystem: warnings from ESPHome
+    # core and the SDKs aren't ours to fix. The generated sources root is the exception
+    # -- it is added with -I below so that `esphome/...` includes resolve.
+    src = str(src_dir)
+    for directory in idedata["includes"]["build"]:
+        if os.path.normpath(directory) != src:
+            cmd += ["-isystem", directory]
+    cmd += ["-I", src]
+
+    return cmd
+
+
+def load_idedata(device_config):
+    """Read the compiled build's idedata (`esphome idedata`, as JSON)."""
+    proc = subprocess.run(
+        ["esphome", "idedata", str(device_config)],
+        capture_output=True,
+        encoding="utf-8",
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stdout + proc.stderr)
+        raise SystemExit(
+            f"esphome idedata failed for {device_config}. Compile it first: "
+            f"esphome compile {device_config}"
+        )
+    # esphome logs to stdout ahead of the JSON document, so decode from the first brace
+    # rather than parsing the whole stream.
+    start = proc.stdout.find("{")
+    if start == -1:
+        raise SystemExit(f"No idedata JSON in esphome output for {device_config}")
+    return json.JSONDecoder().raw_decode(proc.stdout[start:])[0]
+
+
+def find_src_dir(idedata):
+    """Locate the build's generated sources root (`<build_path>/src`).
+
+    That directory holds the device's generated `esphome/core/defines.h` plus the copy
+    of ESPHome core the components include, and it is on the build's own include path,
+    so it can be recovered from idedata instead of re-resolving the device's build_path.
+    """
+    for directory in idedata["includes"]["build"]:
+        path = Path(directory)
+        if path.name == "src" and (path / "esphome" / "core").is_dir():
+            return path
+    raise SystemExit(
+        "Could not find the build's src directory in idedata -- was the device compiled "
+        "with a different ESPHome version?"
+    )
+
+
+def components_in_build(src_dir):
+    """The repo's components that this device actually built, in name order."""
+    built = src_dir / "esphome" / "components"
+    return sorted(
+        path.name
+        for path in COMPONENTS_DIR.iterdir()
+        if path.is_dir() and (built / path.name).is_dir()
+    )
+
+
+def run_tidy(executable, options, header_filter, fix, path):
+    invocation = [executable, f"--header-filter={header_filter}"]
+    if fix:
+        invocation.append("--fix")
+    if sys.stdout.isatty():
+        invocation.append("--use-color")
+    invocation += [str(path), "--"] + options
+
+    proc = subprocess.run(
+        invocation, capture_output=True, encoding="utf-8", check=False
+    )
+    return proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "device",
+        help="name of the compiled device config in devices/ (e.g. pool) supplying the "
+        "build flags",
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        default=[],
+        help="only check files whose path matches one of these regexes",
+    )
+    parser.add_argument("--fix", action="store_true", help="apply fix-its")
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=os.cpu_count(),
+        help="number of clang-tidy instances to run in parallel",
+    )
+    parser.add_argument(
+        "--executable", default="clang-tidy", help="clang-tidy binary to use"
+    )
+    args = parser.parse_args()
+
+    device_config = DEVICES_DIR / f"{args.device}.yaml"
+    if not device_config.is_file():
+        raise SystemExit(f"No such device config: {device_config}")
+
+    idedata = load_idedata(device_config)
+    src_dir = find_src_dir(idedata)
+    options = clang_options(idedata, src_dir)
+
+    components = components_in_build(src_dir)
+    if not components:
+        print(f"{args.device} builds none of this repo's components; nothing to check")
+        return 0
+
+    files = sorted(
+        path
+        for component in components
+        for path in (COMPONENTS_DIR / component).glob("*.cpp")
+    )
+    if args.files:
+        pattern = re.compile("|".join(args.files))
+        files = [path for path in files if pattern.search(path.as_posix())]
+    if not files:
+        print("No files to check")
+        return 0
+
+    # Only our own headers are in scope; ESPHome core and the SDK headers they pull in
+    # are reported against upstream, not here.
+    header_filter = f"{path_regex(COMPONENTS_DIR)}[\\\\/].*"
+
+    print(
+        f"Checking {len(files)} file(s) from {', '.join(components)} "
+        f"against the {args.device} build"
+    )
+    failed = []
+    # --fix rewrites headers shared by several translation units, so serialize it.
+    jobs = 1 if args.fix else max(1, args.jobs)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as executor:
+        futures = {
+            executor.submit(
+                run_tidy, args.executable, options, header_filter, args.fix, path
+            ): path
+            for path in files
+        }
+        for future in concurrent.futures.as_completed(futures):
+            path = futures[future]
+            ok, output = future.result()
+            if not ok:
+                failed.append(path)
+            if output.strip():
+                # Collapse each file's output into a log group on Actions; the
+                # problem matcher still annotates the lines inside it.
+                name = path.relative_to(REPO_ROOT).as_posix()
+                print(f"::group::{name}" if IN_ACTIONS else f"--- {name}")
+                print(output)
+                if IN_ACTIONS:
+                    print("::endgroup::")
+
+    if failed:
+        print("\nclang-tidy failed for:")
+        for path in sorted(failed):
+            print(f"  {path.relative_to(REPO_ROOT).as_posix()}")
+        return 1
+    print("clang-tidy passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The compile jobs added in #88 prove the custom components still build, but a build only catches what the compiler rejects. Upstream ESPHome runs clang-tidy over every C++ source with a large check list; nothing here did, so the components drifted from the conventions and analysis ESPHome core is held to.

Adopting it is not just a matter of pointing clang-tidy at `components/`. clang cannot consume the xtensa/riscv GCC command line the real build uses, and the components only compile against a device's generated `esphome/core/defines.h`. Upstream solves both with dedicated "tidy" PlatformIO environments; this repo has no `platformio.ini` of its own, so the flags come from an actual device build via `esphome idedata` — which the CI compile matrix already produces.

Changes:

- Add `.clang-tidy`, a verbatim copy of upstream's, so a component here is held to exactly the checks it would face in ESPHome core.
- Add `scripts/clang_tidy.py`, a slimmed-down port of upstream's `script/clang-tidy`: it reads the compiled build's idedata, rebuilds the clang command line from it (dropping GCC-only flags, macro-replacing the Arduino/newlib headers that use GNU extensions), and checks only the components that device built, in parallel.
- Run it in the existing compile matrix, right after each `esphome compile`, so it costs no extra build. A component that runs on both platforms is analyzed once per platform, same as the compile itself. Register a problem matcher so findings annotate the diff.
- Two adaptations upstream does not need. It analyzes at `ESPHOME_LOG_LEVEL_VERY_VERBOSE`, because these devices build with `log_level: none`, which preprocesses every `ESP_LOG*` call away — hiding the code inside them and making log-only variables look unused. And it passes `-fgnuc-version=4.2.1`, which is what clang already assumes on Linux; on Windows it defaults to an MSVC target that leaves `__GNUC__` undefined, and newlib's `__GNUC_PREREQ` ladders then fall back to `throw()` exception specifications, a hard error under C++17. CI is unaffected either way.

The new checks found real problems in two components, fixed here so CI lands green:

- **pool_controller**: `reset_all_pump_runtimes_()` logged `this->last_check_->hour` with no `has_value()` guard at all; it now takes the boundary time as a parameter, which also makes it explicit that the value is the walked time while catching up, not the current clock. The catch-up loop's own accesses are unprovable across calls clang-tidy cannot see into, so it binds the contained value once under the guard.
- **econet_zone_control**: `update_zone_fan_mode_()` dereferenced `min_zone`/`max_zone` unconditionally after the scan, which is null if no zones are configured. The schema requires at least two, so this is unreachable today; guarded rather than left to depend on a validator elsewhere.
- **pool_controller**: eight protected methods in `pump_switch.h` now carry the trailing underscore ESPHome uses for non-public members, which the file already used for others. Renamed by hand: clang-tidy's `--fix` renamed `has_current_sensor()` inside `#ifdef USE_SENSOR` and left the `#else` definition on the old name, which builds here and breaks a device without sensors.
- Concatenated nested namespaces across `pool_controller`, and added braces to two multi-line statement bodies.
- The one finding not fixed is a `bugprone-branch-clone` in `update_current_action_()`: `"Off"` is tested first and deliberately shares the fallback's body so it wins over a state string containing another keyword. Suppressed with a NOLINT and the reason, since the datapoint's value set is not documented anywhere.

No behaviour changes on upgrade: the C++ edits are internal renames, guards on unreachable paths, and a log argument that resolves to the same value at every call site. No persisted state is affected.

Verified by compiling all five devices in the CI matrix from scratch copies (`esphome compile`) and running the new script against each build: every component passes.
